### PR TITLE
Article CRUD

### DIFF
--- a/backend/article/build.gradle
+++ b/backend/article/build.gradle
@@ -1,3 +1,8 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    implementation project(':backend:common:snowflake')
+    implementation project(':backend:common:support')
 }

--- a/backend/article/src/main/java/com/example/article/controller/ArticleController.java
+++ b/backend/article/src/main/java/com/example/article/controller/ArticleController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class ArticleController {
@@ -50,5 +52,13 @@ public class ArticleController {
     public ResponseEntity<Void> delete(@PathVariable Long articleId) {
         articleService.delete(articleId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/v1/article/infinite-scroll")
+    public ResponseEntity<List<ArticleResponse>> readAllInfiniteScroll(@RequestParam("boardId") Long boardId,
+                                                                       @RequestParam("pageSize") Long pageSize,
+                                                                       @RequestParam(value = "lastArticleId", required = false) Long lastArticleId
+    ) {
+        return ResponseEntity.ok(articleService.readAllInfiniteScroll(boardId, pageSize, lastArticleId));
     }
 }

--- a/backend/article/src/main/java/com/example/article/controller/ArticleController.java
+++ b/backend/article/src/main/java/com/example/article/controller/ArticleController.java
@@ -1,0 +1,54 @@
+package com.example.article.controller;
+
+import com.example.article.service.ArticleService;
+import com.example.article.service.request.ArticleCreateRequest;
+import com.example.article.service.request.ArticleUpdateRequest;
+import com.example.article.service.response.ArticlePageResponse;
+import com.example.article.service.response.ArticleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ArticleController {
+    private final ArticleService articleService;
+
+    @PostMapping("/v1/article")
+    public ResponseEntity<ArticleResponse> create(@RequestBody ArticleCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(articleService.create(request));
+    }
+
+    @GetMapping("/v1/article/{articleId}")
+    public ResponseEntity<ArticleResponse> read(@PathVariable Long articleId) {
+        return ResponseEntity.ok(articleService.read(articleId));
+    }
+
+    @GetMapping("/v1/article")
+    public ResponseEntity<ArticlePageResponse> readAll(@RequestParam("boardId") Long boardId,
+                                       @RequestParam("page") Long page,
+                                       @RequestParam("pageSize") Long pageSize
+    ) {
+        return ResponseEntity.ok(articleService.readAll(boardId, page, pageSize));
+    }
+
+    @PutMapping("/v1/article/{articleId}")
+    public ResponseEntity<ArticleResponse> update(@PathVariable Long articleId, @RequestBody ArticleUpdateRequest request) {
+        return ResponseEntity.ok(articleService.update(articleId, request));
+    }
+
+    @DeleteMapping("/v1/article/{articleId}")
+    public ResponseEntity<Void> delete(@PathVariable Long articleId) {
+        articleService.delete(articleId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/article/src/main/java/com/example/article/entity/Article.java
+++ b/backend/article/src/main/java/com/example/article/entity/Article.java
@@ -1,0 +1,39 @@
+package com.example.article.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "article")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Article {
+
+    @Id
+    private Long articleId;
+    private String title;
+    private String content;
+    private Long boardId;
+    private Long writerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static Article create(Long articleId, String title, String content, Long boardId, Long writerId) {
+        LocalDateTime now = LocalDateTime.now();
+        return new Article(articleId, title, content, boardId, writerId, now, now);
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.modifiedAt = LocalDateTime.now();
+    }
+}

--- a/backend/article/src/main/java/com/example/article/entity/BoardArticleCount.java
+++ b/backend/article/src/main/java/com/example/article/entity/BoardArticleCount.java
@@ -1,0 +1,25 @@
+package com.example.article.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "board_article_count")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BoardArticleCount {
+
+    @Id
+    private Long boardId;
+    private Long articleCount;
+
+    public static BoardArticleCount of(Long boardId, Long articleCount) {
+        return new BoardArticleCount(boardId, articleCount);
+    }
+}

--- a/backend/article/src/main/java/com/example/article/repository/ArticleRepository.java
+++ b/backend/article/src/main/java/com/example/article/repository/ArticleRepository.java
@@ -1,0 +1,32 @@
+package com.example.article.repository;
+
+import com.example.article.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    @Query(value = " select article.article_id, article.title, article.content, article.board_id, article.writer_id, article.created_at, article.modified_at " +
+            " from ( " +
+            "   select article_id from article " +
+            "   where board_id = :boardId " +
+            "   order by article_id desc " +
+            "   limit :limit offset :offset " +
+            " ) t left join article on t.article_id = article.article_id ",
+            nativeQuery = true)
+    List<Article> findAll(@Param("boardId") Long boardId,
+                          @Param("offset") Long offset,
+                          @Param("limit") Long limit);
+
+    @Query(value = "select count(*) from ( " +
+            "   select article_id from article " +
+            "   where board_id = :boardId " +
+            "   limit :limit " +
+            ") t",
+            nativeQuery = true)
+    Long count(@Param("boardId") Long boardId, @Param("limit") Long limit);
+}

--- a/backend/article/src/main/java/com/example/article/repository/ArticleRepository.java
+++ b/backend/article/src/main/java/com/example/article/repository/ArticleRepository.java
@@ -29,4 +29,27 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             ") t",
             nativeQuery = true)
     Long count(@Param("boardId") Long boardId, @Param("limit") Long limit);
+
+    @Query(
+        value = " select * from article " +
+                " where board_id = :boardId " +
+                " order by article_id desc limit :limit" ,
+        nativeQuery = true
+    )
+    List<Article> readAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+            value = " select * from article " +
+                    " where board_id = :boardId and article_id < :lastArticleId " +
+                    " order by article_id desc limit :limit" ,
+            nativeQuery = true
+    )
+    List<Article> readAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit,
+            @Param("lastArticleId") Long lastArticleId
+    );
 }

--- a/backend/article/src/main/java/com/example/article/repository/BoardArticleCountRepository.java
+++ b/backend/article/src/main/java/com/example/article/repository/BoardArticleCountRepository.java
@@ -1,0 +1,21 @@
+package com.example.article.repository;
+
+import com.example.article.entity.BoardArticleCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardArticleCountRepository extends JpaRepository<BoardArticleCount, Long> {
+    @Query(value = "update board_article_count set article_count = article_count + 1 where board_id = :boardId",
+            nativeQuery = true)
+    @Modifying(clearAutomatically = true)
+    int increase(@Param("boardId") Long boardId);
+
+    @Query(value = "update board_article_count set article_count = article_count - 1 where board_id = :boardId",
+            nativeQuery = true)
+    @Modifying(clearAutomatically = true)
+    int decrease(@Param("boardId") Long boardId);
+}

--- a/backend/article/src/main/java/com/example/article/service/ArticleService.java
+++ b/backend/article/src/main/java/com/example/article/service/ArticleService.java
@@ -1,0 +1,66 @@
+package com.example.article.service;
+
+import com.example.article.entity.Article;
+import com.example.article.entity.BoardArticleCount;
+import com.example.article.repository.ArticleRepository;
+import com.example.article.repository.BoardArticleCountRepository;
+import com.example.article.service.request.ArticleCreateRequest;
+import com.example.article.service.request.ArticleUpdateRequest;
+import com.example.article.service.response.ArticlePageResponse;
+import com.example.article.service.response.ArticleResponse;
+import com.example.snowflake.Snowflake;
+import com.example.support.PageLimitCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ArticleService {
+    private final Snowflake snowflake = new Snowflake();
+
+    private final ArticleRepository articleRepository;
+    private final BoardArticleCountRepository boardArticleCountRepository;
+
+    public ArticleResponse create(ArticleCreateRequest request) {
+        Article saved = articleRepository.save(Article.create(snowflake.nextId(), request.getTitle(), request.getContent(), request.getBoardId(), request.getWriterId()));
+        int result = boardArticleCountRepository.increase(request.getBoardId());
+        if(result == 0) {
+            boardArticleCountRepository.save(BoardArticleCount.of(request.getBoardId(), 1L));
+        }
+
+        return ArticleResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleResponse read(Long articleId) {
+        Article article = articleRepository.findById(articleId).orElseThrow();
+        return ArticleResponse.from(article);
+    }
+
+    @Transactional(readOnly = true)
+    public ArticlePageResponse readAll(Long boardId, Long page, Long pageSize) {
+        List<Article> articles = articleRepository.findAll(boardId, (page - 1) * pageSize, pageSize);
+        Long count = articleRepository.count(boardId, PageLimitCalculator.pageLimit(page, pageSize, 10L));
+        return new ArticlePageResponse(
+                articles.stream().map(ArticleResponse::from).toList(),
+                count
+        );
+    }
+
+    public ArticleResponse update(Long articleId, ArticleUpdateRequest request) {
+        Article article = articleRepository.findById(articleId).orElseThrow();
+        article.update(request.getTitle(), request.getContent());
+        return ArticleResponse.from(article);
+    }
+
+    public void delete(Long articleId) {
+        Article article = articleRepository.findById(articleId).orElseThrow();
+        articleRepository.delete(article);
+        boardArticleCountRepository.decrease(article.getBoardId());
+    }
+
+}

--- a/backend/article/src/main/java/com/example/article/service/ArticleService.java
+++ b/backend/article/src/main/java/com/example/article/service/ArticleService.java
@@ -63,4 +63,19 @@ public class ArticleService {
         boardArticleCountRepository.decrease(article.getBoardId());
     }
 
+    @Transactional(readOnly = true)
+    public List<ArticleResponse> readAllInfiniteScroll(Long boardId, Long pageSize, Long lastArticleId) {
+        List<Article> articles = lastArticleId == null ?
+                articleRepository.readAllInfiniteScroll(boardId, pageSize)
+                : articleRepository.readAllInfiniteScroll(boardId, pageSize, lastArticleId);
+
+        return articles.stream().map(ArticleResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Long count(Long boardId) {
+        return boardArticleCountRepository.findById(boardId)
+                .map(BoardArticleCount::getArticleCount)
+                .orElse(0L);
+    }
 }

--- a/backend/article/src/main/java/com/example/article/service/request/ArticleCreateRequest.java
+++ b/backend/article/src/main/java/com/example/article/service/request/ArticleCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.article.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ArticleCreateRequest {
+    private String title;
+    private String content;
+    private Long writerId;
+    private Long boardId;
+}

--- a/backend/article/src/main/java/com/example/article/service/request/ArticleUpdateRequest.java
+++ b/backend/article/src/main/java/com/example/article/service/request/ArticleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.article.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ArticleUpdateRequest {
+    private String title;
+    private String content;
+}

--- a/backend/article/src/main/java/com/example/article/service/response/ArticlePageResponse.java
+++ b/backend/article/src/main/java/com/example/article/service/response/ArticlePageResponse.java
@@ -1,0 +1,13 @@
+package com.example.article.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ArticlePageResponse {
+    private List<ArticleResponse> articles;
+    private Long count;
+}

--- a/backend/article/src/main/java/com/example/article/service/response/ArticleResponse.java
+++ b/backend/article/src/main/java/com/example/article/service/response/ArticleResponse.java
@@ -1,0 +1,31 @@
+package com.example.article.service.response;
+
+import com.example.article.entity.Article;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ArticleResponse {
+    private Long articleId;
+    private String title;
+    private String content;
+    private Long boardId;
+    private Long writerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ArticleResponse from(Article article) {
+        return new ArticleResponse(
+                article.getArticleId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getBoardId(),
+                article.getWriterId(),
+                article.getCreatedAt(),
+                article.getModifiedAt()
+        );
+    }
+}

--- a/backend/article/src/test/java/com/example/article/controller/ArticleControllerTest.java
+++ b/backend/article/src/test/java/com/example/article/controller/ArticleControllerTest.java
@@ -1,0 +1,136 @@
+package com.example.article.controller;
+
+import com.example.article.entity.Article;
+import com.example.article.repository.ArticleRepository;
+import com.example.article.service.request.ArticleCreateRequest;
+import com.example.article.service.request.ArticleUpdateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class ArticleControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @BeforeEach
+    void setUp() {
+        List<Article> articles = new ArrayList<>();
+        for(int i = 1; i <= 100; i++) {
+            articles.add(create((long) i));
+        }
+
+        articleRepository.saveAll(articles);
+        articleRepository.flush();;
+    }
+
+    private static Article create(Long articleId) {
+        return Article.create(articleId,
+                "제목" + articleId,
+                "콘텐츠" + articleId,
+                1L,
+                1L
+        );
+    }
+
+    @Test
+    void createTest() throws Exception {
+        ArticleCreateRequest request = new ArticleCreateRequest("제목", "콘텐츠", 1L, 1L);
+
+        mockMvc.perform(post("/v1/article")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpectAll(
+                        jsonPath("$.articleId").isNotEmpty(),
+                        jsonPath("$.title").value("제목"),
+                        jsonPath("$.content").value("콘텐츠"),
+                        jsonPath("$.writerId").value(1L),
+                        jsonPath("$.boardId").value(1L),
+                        jsonPath("$.createdAt").isNotEmpty(),
+                        jsonPath("$.modifiedAt").isNotEmpty()
+                );
+    }
+
+    @Test
+    void readTest() throws Exception {
+        long articleId = 1L;
+
+        mockMvc.perform(get("/v1/article/{articleId}", articleId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.articleId").value(articleId));
+    }
+
+    @Test
+    void readAllTest() throws Exception {
+        String boardId = "1";
+        String page = "2";
+        String pageSize = "5"; // 51개가 있어야 페이징 버튼 10개 출력
+
+        mockMvc.perform(get("/v1/article")
+                .param("boardId", boardId)
+                .param("page", page)
+                .param("pageSize", pageSize)
+        ).andExpect(status().isOk())
+        .andExpectAll(
+                jsonPath("$.articles.size()").value(5),
+                jsonPath("$.count").value(51));
+    }
+
+    @Test
+    void updateTest() throws Exception {
+        long articleId = 1L;
+        String title = "수정된 제목";
+        String content = "수정된 콘텐츠";
+        ArticleUpdateRequest request = new ArticleUpdateRequest(title, content);
+
+        mockMvc.perform(put("/v1/article/{articleId}", articleId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpectAll(
+                        status().isOk(),
+                        jsonPath("$.articleId").value(articleId),
+                        jsonPath("$.title").value(title),
+                        jsonPath("$.content").value(content),
+                        jsonPath("$.createdAt").isNotEmpty(),
+                        jsonPath("$.modifiedAt").isNotEmpty()
+                );
+    }
+
+    @Test
+    void deleteTest() throws Exception {
+        long articleId = 1L;
+        mockMvc.perform(delete("/v1/article/{articleId}", articleId))
+                .andExpect(status().isNoContent());
+
+        boolean exists = articleRepository.findById(articleId).isPresent();
+        assertThat(exists).isFalse();
+    }
+}

--- a/backend/article/src/test/java/com/example/article/repository/ArticleRepositoryTest.java
+++ b/backend/article/src/test/java/com/example/article/repository/ArticleRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.example.article.repository;
 
 import com.example.article.entity.Article;
-import com.example.snowflake.Snowflake;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +54,22 @@ class ArticleRepositoryTest {
         Long count = articleRepository.count(1L, 101L);
 
         assertThat(count).isEqualTo(100);
+    }
+
+    @Test
+    void firstReadAllInfiniteScroll() {
+        List<Article> articles = articleRepository.readAllInfiniteScroll(1L, 10L);
+
+        assertThat(articles).hasSize(10);
+    }
+
+    @Test
+    void secondReadAllInfiniteScroll() {
+        List<Article> articles = articleRepository.readAllInfiniteScroll(1L, 10L, 40L);
+
+        assertThat(articles).hasSize(10);
+        assertThat(articles).extracting(Article::getArticleId)
+                .allMatch(articleId-> articleId < 40);
     }
 
 }

--- a/backend/article/src/test/java/com/example/article/repository/ArticleRepositoryTest.java
+++ b/backend/article/src/test/java/com/example/article/repository/ArticleRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.example.article.repository;
+
+import com.example.article.entity.Article;
+import com.example.snowflake.Snowflake;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest(showSql = false)
+class ArticleRepositoryTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @BeforeEach
+    void setUp() {
+        List<Article> articles = new ArrayList<>();
+        for(int i = 0; i < 100; i++) {
+            articles.add(Article.create((long) i, "title" + i, "content" + i, 1L, 1L));
+        }
+        articleRepository.saveAll(articles);
+    }
+
+    @Test
+    void findAll() {
+        List<Article> articles = articleRepository.findAll(1L, 20L, 10L);
+
+        assertThat(articles.size()).isEqualTo(10);
+    }
+
+    @Test
+    void findAllWhenOverRange() {
+        List<Article> articles = articleRepository.findAll(1L, 100L, 10L);
+
+        assertThat(articles).isEmpty();
+    }
+
+    @Test
+    void count() {
+        Long count = articleRepository.count(1L, 11L);
+
+        assertThat(count).isEqualTo(11L);
+    }
+
+    @Test
+    void countWhenOver() {
+        Long count = articleRepository.count(1L, 101L);
+
+        assertThat(count).isEqualTo(100);
+    }
+
+}

--- a/backend/article/src/test/java/com/example/article/repository/BoardArticleCountRepositoryTest.java
+++ b/backend/article/src/test/java/com/example/article/repository/BoardArticleCountRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.example.article.repository;
+
+import com.example.article.entity.BoardArticleCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class BoardArticleCountRepositoryTest {
+    @Autowired
+    private BoardArticleCountRepository boardArticleCountRepository;
+
+    @BeforeEach
+    void setUp() {
+        boardArticleCountRepository.save(new BoardArticleCount(1L, 10L));
+    }
+
+    @Test
+    void increase() {
+        long boardId = 1L;
+
+        int result = boardArticleCountRepository.increase(boardId);
+        Long articleCount = boardArticleCountRepository.findById(boardId).map(BoardArticleCount::getArticleCount).orElseThrow();
+
+        assertThat(result).isEqualTo(1);
+        assertThat(articleCount).isEqualTo(11L);
+    }
+
+    @Test
+    void increaseFail() {
+        long boardId = 99L;
+
+        int result = boardArticleCountRepository.increase(boardId);
+
+        assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    void decrease() {
+        long boardId = 1L;
+
+        int result = boardArticleCountRepository.decrease(boardId);
+        Long articleCount = boardArticleCountRepository.findById(boardId).map(BoardArticleCount::getArticleCount).orElseThrow();
+
+        assertThat(result).isEqualTo(1);
+        assertThat(articleCount).isEqualTo(9L);
+    }
+
+    @Test
+    void decreaseFail() {
+        long boardId = 99L;
+        int result = boardArticleCountRepository.decrease(boardId);
+
+        assertThat(result).isEqualTo(0);
+    }
+}

--- a/backend/article/src/test/java/com/example/article/service/ArticleServiceTest.java
+++ b/backend/article/src/test/java/com/example/article/service/ArticleServiceTest.java
@@ -152,4 +152,31 @@ class ArticleServiceTest {
         return Article.create(articleId, "제목", "콘텐츠", 1L, 1L);
     }
 
+    @Test
+    void readAllInfiniteScrollWhenLastArticleIdIsNull() {
+        Long boardId = 1L;
+        Long pageSize = 10L;
+
+        when(articleRepository.readAllInfiniteScroll(boardId, pageSize))
+                .thenReturn(List.of(create(boardId)));
+
+        List<ArticleResponse> articleResponses = articleService.readAllInfiniteScroll(boardId, pageSize, null);
+
+        assertThat(articleResponses).hasSize(1);
+        verify(articleRepository, times(1)).readAllInfiniteScroll(boardId, pageSize);
+    }
+
+    @Test
+    void readAllInfiniteScrollWhenLastArticleIdIsNotNull() {
+        Long boardId = 1L;
+        Long pageSize = 10L;
+        Long lastArticleId = 40L;
+        when(articleRepository.readAllInfiniteScroll(boardId, pageSize, lastArticleId))
+                .thenReturn(List.of(create(boardId)));
+
+        List<ArticleResponse> articleResponses = articleService.readAllInfiniteScroll(boardId, pageSize, lastArticleId);
+
+        assertThat(articleResponses).hasSize(1);
+        verify(articleRepository, times(1)).readAllInfiniteScroll(boardId, pageSize, lastArticleId);
+    }
 }

--- a/backend/article/src/test/java/com/example/article/service/ArticleServiceTest.java
+++ b/backend/article/src/test/java/com/example/article/service/ArticleServiceTest.java
@@ -1,0 +1,155 @@
+package com.example.article.service;
+
+import com.example.article.entity.Article;
+import com.example.article.repository.ArticleRepository;
+import com.example.article.repository.BoardArticleCountRepository;
+import com.example.article.service.request.ArticleCreateRequest;
+import com.example.article.service.request.ArticleUpdateRequest;
+import com.example.article.service.response.ArticlePageResponse;
+import com.example.article.service.response.ArticleResponse;
+import com.example.snowflake.Snowflake;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    private final Snowflake snowflake = new Snowflake();
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private BoardArticleCountRepository boardArticleCountRepository;
+
+    @InjectMocks
+    private ArticleService articleService;
+
+
+    @Test
+    void create() {
+        ArticleCreateRequest request = new ArticleCreateRequest("제목", "콘텐츠", 1L, 1L);
+        Article article = create(snowflake.nextId());
+
+        when(articleRepository.save(any()))
+                .thenReturn(article);
+        when(boardArticleCountRepository.increase(anyLong()))
+                .thenReturn(1);
+
+        ArticleResponse result = articleService.create(request);
+
+        assertThat(result).extracting(ArticleResponse::getTitle, ArticleResponse::getContent)
+                .containsExactly(article.getTitle(), article.getContent());
+
+        verify(boardArticleCountRepository, never()).save(any());
+    }
+
+    @Test
+    void createWhenFirstArticle() {
+        ArticleCreateRequest request = new ArticleCreateRequest("제목", "콘텐츠", 1L, 1L);
+        Article article = create(snowflake.nextId());
+
+        when(articleRepository.save(any()))
+                .thenReturn(article);
+        when(boardArticleCountRepository.increase(anyLong()))
+                .thenReturn(0);
+
+        ArticleResponse result = articleService.create(request);
+
+        assertThat(result).extracting(ArticleResponse::getTitle, ArticleResponse::getContent)
+                .containsExactly(article.getTitle(), article.getContent());
+
+        verify(boardArticleCountRepository, times(1)).save(any());
+    }
+
+    @Test
+    void read() {
+        Long articleId = snowflake.nextId();
+
+        when(articleRepository.findById(articleId))
+                .thenReturn(Optional.of(create(articleId)));
+
+        ArticleResponse result = articleService.read(articleId);
+
+        assertThat(result.getArticleId()).isEqualTo(articleId);
+    }
+
+    @Test
+    void readWhenNoneExists() {
+        Long articleId = snowflake.nextId();
+
+        when(articleRepository.findById(articleId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> articleService.read(articleId))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void readAll() {
+        Long boardId = 1L;
+        Long page = 1L;
+        Long pageSize = 10L;
+
+        when(articleRepository.findAll(anyLong(), anyLong(), anyLong()))
+            .thenReturn(List.of(create(snowflake.nextId()), create(snowflake.nextId()), create(snowflake.nextId())));
+        when(articleRepository.count(anyLong(), anyLong()))
+                .thenReturn(3L);
+
+        ArticlePageResponse articlePageResponse = articleService.readAll(boardId, page, pageSize);
+
+        assertThat(articlePageResponse.getArticles()).hasSize(3);
+        assertThat(articlePageResponse.getCount()).isEqualTo(3L);
+    }
+
+    @Test
+    void update() {
+        Long articleId = snowflake.nextId();
+        String title = "수정 제목";
+        String content = "수정 콘텐츠";
+        ArticleUpdateRequest request = new ArticleUpdateRequest(title, content);
+
+        when(articleRepository.findById(articleId))
+                .thenReturn(Optional.of(create(articleId)));
+
+        ArticleResponse result = articleService.update(articleId, request);
+
+        assertThat(result).extracting(ArticleResponse::getArticleId, ArticleResponse::getTitle, ArticleResponse::getContent)
+                .containsExactly(articleId, title, content);
+
+    }
+
+    @Test
+    void delete() {
+        Long articleId = snowflake.nextId();
+
+        when(articleRepository.findById(articleId))
+                .thenReturn(Optional.of(create(articleId)));
+
+        articleService.delete(articleId);
+
+        verify(articleRepository).delete(any());
+        verify(boardArticleCountRepository).decrease(anyLong());
+    }
+
+    private static Article create(Long articleId) {
+        return Article.create(articleId, "제목", "콘텐츠", 1L, 1L);
+    }
+
+}

--- a/backend/article/src/test/resources/application-test.yml
+++ b/backend/article/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+    defer-datasource-initialization: true

--- a/backend/common/snowflake/src/main/java/com/example/snowflake/Snowflake.java
+++ b/backend/common/snowflake/src/main/java/com/example/snowflake/Snowflake.java
@@ -1,0 +1,50 @@
+package com.example.snowflake;
+
+import java.util.random.RandomGenerator;
+
+public class Snowflake {
+    private static final int UNUSED_BITS = 1;
+    private static final int EPOCH_BITS = 41;
+    private static final int NODE_ID_BITS = 10;
+    private static final int SEQUENCE_BITS = 12;
+
+    private static final long maxNodeId = (1L << NODE_ID_BITS) - 1;
+    private static final long maxSequence = (1L << SEQUENCE_BITS) - 1;
+
+    private final long nodeId = RandomGenerator.getDefault().nextLong(maxNodeId + 1);
+    // UTC = 2024-01-01T00:00:00Z
+    private final long startTimeMillis = 1704067200000L;
+
+    private long lastTimeMillis = startTimeMillis;
+    private long sequence = 0L;
+
+    public synchronized long nextId() {
+        long currentTimeMillis = System.currentTimeMillis();
+
+        if (currentTimeMillis < lastTimeMillis) {
+            throw new IllegalStateException("Invalid Time");
+        }
+
+        if (currentTimeMillis == lastTimeMillis) {
+            sequence = (sequence + 1) & maxSequence;
+            if (sequence == 0) {
+                currentTimeMillis = waitNextMillis(currentTimeMillis);
+            }
+        } else {
+            sequence = 0;
+        }
+
+        lastTimeMillis = currentTimeMillis;
+
+        return ((currentTimeMillis - startTimeMillis) << (NODE_ID_BITS + SEQUENCE_BITS))
+                | (nodeId << SEQUENCE_BITS)
+                | sequence;
+    }
+
+    private long waitNextMillis(long currentTimestamp) {
+        while (currentTimestamp <= lastTimeMillis) {
+            currentTimestamp = System.currentTimeMillis();
+        }
+        return currentTimestamp;
+    }
+}

--- a/backend/common/snowflake/src/test/java/com/example/snowflake/SnowflakeTest.java
+++ b/backend/common/snowflake/src/test/java/com/example/snowflake/SnowflakeTest.java
@@ -1,0 +1,77 @@
+package com.example.snowflake;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SnowflakeTest {
+    private final Snowflake snowflake = new Snowflake();
+
+    @DisplayName("중복없이 오름차순으로 원하는 갯수 만큼 유니크한 아이디를 만든다")
+    @Test
+    void nextIdTest() throws ExecutionException, InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        List<Future<List<Long>>> futures = new ArrayList<>();
+        int repeatCount = 1000;
+        int idCount = 1000;
+
+        for(int i = 0; i < repeatCount; i++) {
+            futures.add(executorService.submit(() -> generateIdList(idCount)));
+        }
+
+        List<Long> result = new ArrayList<>();
+        for(Future<List<Long>> future : futures) {
+            List<Long> ids = future.get();
+            for(int i = 1; i < ids.size(); i++) {
+                assertThat(ids.get(i)).isGreaterThan(ids.get(i - 1));
+            }
+            result.addAll(ids);
+        }
+
+        long expected = repeatCount * idCount;
+        long actual = result.stream().distinct().count();
+        assertThat(actual).isEqualTo(expected);
+
+        executorService.shutdown();
+    }
+
+    private List<Long> generateIdList(int count) {
+        List<Long> ids = new ArrayList<>();
+        for(int i = 1; i <= count; i++) {
+            ids.add(snowflake.nextId());
+        }
+
+        return ids;
+    }
+
+    @Test
+    void performanceTest() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        int repeatCount = 1000;
+        int idCount = 1000;
+        CountDownLatch latch = new CountDownLatch(repeatCount);
+
+        long start = System.currentTimeMillis();
+        for(int i = 0; i < repeatCount; i++) {
+            executorService.submit(() -> {
+                generateIdList(idCount);
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        long end = System.currentTimeMillis();
+
+        System.out.printf("times = %s ms%n", end - start);
+        executorService.shutdown();
+    }
+}

--- a/backend/common/support/src/main/java/com/example/support/PageLimitCalculator.java
+++ b/backend/common/support/src/main/java/com/example/support/PageLimitCalculator.java
@@ -1,0 +1,11 @@
+package com.example.support;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageLimitCalculator {
+    public static Long pageLimit(Long page, Long pageSize, Long movablePageCount) {
+        return (((page - 1) / movablePageCount) + 1) * pageSize * movablePageCount + 1;
+    }
+}

--- a/backend/common/support/src/test/java/com/example/support/PageLimitCalculatorTest.java
+++ b/backend/common/support/src/test/java/com/example/support/PageLimitCalculatorTest.java
@@ -1,0 +1,27 @@
+package com.example.support;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageLimitCalculatorTest {
+
+    @ParameterizedTest
+    @CsvSource({
+           "1, 10, 10, 101",
+           "7, 30, 10, 301",
+           "11, 30, 10, 601",
+           "20, 30, 10, 601",
+           "21, 30, 10, 901",
+    })
+    void pageLimitTest(Long page, Long pageSize, Long movablePageCount, Long expected) {
+        calculatePageLimitBy(page, pageSize, movablePageCount, expected);
+    }
+
+    void calculatePageLimitBy(Long page, Long pageSize, Long movablePageCount, Long expected) {
+        Long result = PageLimitCalculator.pageLimit(page, pageSize, movablePageCount);
+        assertThat(result).isEqualTo(expected);
+    }
+
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  mysql:
+    container_name: board-mysql
+    image: mysql:8.0.38
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --explicit_defaults_for_timestamp=1
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+      - MYSQL_DATABASE=board
+      - MYSQL_USER=tester
+      - MYSQL_PASSWORD=1234
+      - TZ=UTC
+    volumes:
+      - ./mysql/init:/docker-entrypoint-initdb.d
+  redis:
+    image: redis:7.4
+    container_name: board-redis
+    ports:
+      - "6379:6379"

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -1,0 +1,16 @@
+create table article (
+     article_id bigint not null primary key,
+     title varchar(100) not null,
+     content varchar(3000) not null,
+     board_id bigint not null,
+     writer_id bigint not null,
+     created_at datetime not null,
+     modified_at datetime not null
+);
+
+create index idx_board_id_article_id on article(board_id asc, article_id desc);
+
+create table board_article_count (
+     board_id bigint not null primary key,
+     article_count bigint not null
+);

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'boardx'
 
 include('backend')
-include('backend:article', 'backend:article-read', 'backend:comment', 'backend:common', 'backend:hot-article', 'backend:like', 'backend:view')
+include('backend:article', 'backend:article-read', 'backend:comment', 'backend:hot-article', 'backend:like', 'backend:view')
+include('backend:common', 'backend:common:snowflake', 'backend:common:support')


### PR DESCRIPTION
![article_erd](https://github.com/user-attachments/assets/a731a3f6-6083-4d77-b0ff-8f72cbe0a683)

- **Article** CRUD 생성
  - articleId는 Snowflake 사용 (분산 환경 가정) 
  - boardId 를 샤딩키로 가정  
- **BoardArticleCount** 생성
  - Board 마다 Article 개수를 카운팅
- 페이징 조회 구현  
- 무한 스크롤 조회 구현 
   - Article 추가/삭제로 인해 데이터 중복이나 누락을 방지하기 위해 `lastArticleId` 기준으로 조회
   - `lastArticleId` 없는 경우 처음부터 pageSize 만큼 조회
   - `lastArticleId` 있는 경우 `lastArticleId` 미만으로 pageSize 만큼 조회

**커버링 인덱스 사용 전후 속도 비교**
```sql 
// 1.67s
select count(*)  from article where board_id = 1 limit 300301

// 0.08s
select count(*) from (
	select article_id  from article where board_id = 1 limit 300301
) t
```
