### PR TITLE
Comment crud

### DIFF
--- a/backend/comment/build.gradle
+++ b/backend/comment/build.gradle
@@ -1,3 +1,8 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+    implementation project(':backend:common:snowflake')
+    implementation project(':backend:common:support')
 }

--- a/backend/comment/src/main/java/com/example/comment/controller/CommentController.java
+++ b/backend/comment/src/main/java/com/example/comment/controller/CommentController.java
@@ -1,0 +1,62 @@
+package com.example.comment.controller;
+
+import com.example.comment.service.CommentService;
+import com.example.comment.service.request.CommentCreateRequest;
+import com.example.comment.service.response.CommentPageResponse;
+import com.example.comment.service.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping("/v1/comment")
+    public ResponseEntity<CommentResponse> create(@RequestBody CommentCreateRequest request) {
+        CommentResponse response = commentService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/v1/comment/{commentId}")
+    public ResponseEntity<CommentResponse> read(@PathVariable("commentId") Long commentId) {
+        return ResponseEntity.ok(commentService.read(commentId));
+    }
+
+    @GetMapping("/v1/comment")
+    public ResponseEntity<CommentPageResponse> readAll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam("page") Long page,
+            @RequestParam("pageSize") Long pageSize
+    ) {
+        return ResponseEntity.ok(commentService.readAll(articleId, page, pageSize));
+    }
+
+    @GetMapping("/v1/comment/infinite-scroll")
+    public ResponseEntity<List<CommentResponse>> readAllInfiniteScroll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam(value = "lastParentCommentId", required = false) Long lastParentCommentId,
+            @RequestParam(value = "lastCommentId", required = false) Long lastCommentId,
+            @RequestParam("pageSize") Long pageSize
+    ) {
+        List<CommentResponse> commentResponses = commentService.readAllInfiniteScroll(articleId, lastParentCommentId, lastCommentId, pageSize);
+        return ResponseEntity.ok(commentResponses);
+    }
+
+    @DeleteMapping("/v1/comment/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable("commentId") Long commentId) {
+        commentService.delete(commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/backend/comment/src/main/java/com/example/comment/controller/CommentControllerV2.java
+++ b/backend/comment/src/main/java/com/example/comment/controller/CommentControllerV2.java
@@ -1,0 +1,61 @@
+package com.example.comment.controller;
+
+import com.example.comment.service.CommentServiceV2;
+import com.example.comment.service.request.CommentCreateRequestV2;
+import com.example.comment.service.response.CommentPageResponseV2;
+import com.example.comment.service.response.CommentResponseV2;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// 열겨형 path 활용한 무한 depth 방식
+@RestController
+@RequiredArgsConstructor
+public class CommentControllerV2 {
+    private final CommentServiceV2 commentService;
+
+    @PostMapping("/v2/comment")
+    public ResponseEntity<CommentResponseV2> create(@RequestBody CommentCreateRequestV2 request) {
+        CommentResponseV2 response = commentService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/v2/comment/{commentId}")
+    public ResponseEntity<CommentResponseV2> read(@PathVariable("commentId") Long commentId) {
+        return ResponseEntity.ok(commentService.read(commentId));
+    }
+
+    @GetMapping("/v2/comment")
+    public ResponseEntity<CommentPageResponseV2> readAll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam(value = "page", defaultValue = "1") Long page,
+            @RequestParam(value = "pageSize", defaultValue = "10") Long pageSize
+    ) {
+        return ResponseEntity.ok(commentService.readAll(articleId, page, pageSize));
+    }
+
+    @GetMapping("/v2/comment/infinite-scroll")
+    public ResponseEntity<List<CommentResponseV2>> readAllInfiniteScroll(
+            @RequestParam("articleId") Long articleId,
+            @RequestParam(value = "lastPath", required = false) String lastPath,
+            @RequestParam(value = "pageSize", defaultValue = "10") Long pageSize
+    ) {
+        List<CommentResponseV2> commentResponses = commentService.readAllInfiniteScroll(articleId, lastPath, pageSize);
+        return ResponseEntity.ok(commentResponses);
+    }
+
+    @DeleteMapping("/v2/comment/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable("commentId") Long commentId) {
+        commentService.delete(commentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/entity/ArticleCommentCount.java
+++ b/backend/comment/src/main/java/com/example/comment/entity/ArticleCommentCount.java
@@ -1,0 +1,24 @@
+package com.example.comment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "article_comment_count")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ArticleCommentCount {
+    @Id
+    private Long articleId;
+    private Long commentCount;
+
+    public static ArticleCommentCount of(Long articleId, Long commentCount) {
+        return new ArticleCommentCount(articleId, commentCount);
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/entity/Comment.java
+++ b/backend/comment/src/main/java/com/example/comment/entity/Comment.java
@@ -1,0 +1,47 @@
+package com.example.comment.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "comment")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment {
+    @Id
+    private Long commentId;
+    private String content;
+    private Long parentCommentId;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+
+    public static Comment of(Long commentId, String content, Long parentCommentId, Long articleId, Long writerId) {
+        Comment comment = new Comment();
+        comment.commentId = commentId;
+        comment.content = content;
+        comment.parentCommentId = parentCommentId == null ? commentId : parentCommentId;
+        comment.articleId = articleId;
+        comment.writerId = writerId;
+        comment.deleted = false;
+        comment.createdAt = LocalDateTime.now();
+        return comment;
+    }
+
+    public boolean isRoot() {
+        return parentCommentId.longValue() == commentId;
+    }
+
+    public void delete() {
+        this.deleted = true;
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/entity/CommentPath.java
+++ b/backend/comment/src/main/java/com/example/comment/entity/CommentPath.java
@@ -1,0 +1,119 @@
+package com.example.comment.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentPath {
+    private static final String CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int DEPTH_CHUNK_SIZE = 5;
+    private static final int MAX_DEPTH = 5;
+
+    // MIN_CHUNK = "00000", MAX_CHUNK = "zzzzz"
+    private static final String MIN_CHUNK = String.valueOf(CHARSET.charAt(0)).repeat(DEPTH_CHUNK_SIZE);
+    private static final String MAX_CHUNK = String.valueOf(CHARSET.charAt(CHARSET.length() - 1)).repeat(DEPTH_CHUNK_SIZE);
+
+    private String path;
+
+    public CommentPath(String path) {
+        this.path = path;
+    }
+
+    public static CommentPath create(String path) {
+        if(isDepthOverflow(path)) {
+            throw new IllegalStateException("Depth overflow");
+        }
+
+        return new CommentPath(path);
+    }
+
+    private static boolean isDepthOverflow(String path) {
+        return calculateDepth(path) > MAX_DEPTH;
+    }
+
+    private static int calculateDepth(String path) {
+        return path.length() / DEPTH_CHUNK_SIZE;
+    }
+
+    public int getDepth() {
+        return calculateDepth(path);
+    }
+
+    public boolean isRoot() {
+        return calculateDepth(path) == 1;
+    }
+
+    public String getParentPath() {
+        return path.substring(0, path.length() - DEPTH_CHUNK_SIZE);
+    }
+
+    public CommentPath createChildCommentPath(String descendantsTopPath) {
+        if(descendantsTopPath == null) {
+            return CommentPath.create(path + MIN_CHUNK);
+        }
+
+        String childrenTopPath = findChildrenTopPath(descendantsTopPath);
+        return CommentPath.create(increase(childrenTopPath));
+    }
+
+    private String findChildrenTopPath(String descendantsTopPath) {
+        return descendantsTopPath.substring(0, (getDepth() + 1) * DEPTH_CHUNK_SIZE);
+    }
+
+    private String increase(String path) {
+        String lastChunk = path.substring(path.length() - DEPTH_CHUNK_SIZE);
+        if(isChunkOverflow(lastChunk)) {
+            throw new IllegalStateException("Chunk overflow");
+        }
+
+        String result = convertPath(plusOne(lastChunk));
+        return path.substring(0, path.length() - DEPTH_CHUNK_SIZE) + result;
+    }
+
+    private static String convertPath(int value) {
+        int charsetLength = CHARSET.length();
+
+        String result = "";
+        for(int i = 0; i < DEPTH_CHUNK_SIZE; i++) {
+            result = CHARSET.charAt(value % charsetLength) + result;
+            value /= charsetLength;
+        }
+
+        return result;
+    }
+
+    private static int plusOne(String lastChunk) {
+        int charsetLength = CHARSET.length();
+
+        int value = 0;
+        for(char c : lastChunk.toCharArray()) {
+            value = value * charsetLength + CHARSET.indexOf(c);
+        }
+        value += 1;
+
+        return value;
+    }
+
+    private boolean isChunkOverflow(String lastChunk) {
+        return MAX_CHUNK.equals(lastChunk);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CommentPath that = (CommentPath) o;
+        return Objects.equals(getPath(), that.getPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getPath());
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/entity/CommentV2.java
+++ b/backend/comment/src/main/java/com/example/comment/entity/CommentV2.java
@@ -1,0 +1,56 @@
+package com.example.comment.entity;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "comment_v2")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentV2 {
+
+    @Id
+    private Long commentId;
+    private String content;
+    private Long articleId;
+    private Long writerId;
+    @Embedded
+    private CommentPath commentPath;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+
+    public static CommentV2 of(Long commentId, String content, Long articleId, Long writerId, CommentPath commentPath) {
+        CommentV2 comment = new CommentV2();
+        comment.commentId = commentId;
+        comment.content = content;
+        comment.articleId = articleId;
+        comment.writerId = writerId;
+        comment.commentPath = commentPath;
+        comment.deleted = Boolean.FALSE;
+        comment.createdAt = LocalDateTime.now();
+        return comment;
+    }
+
+    public boolean isRoot() {
+        return commentPath.isRoot();
+    }
+
+    public String getPath() {
+        return commentPath.getPath();
+    }
+
+    public String getParentPath() {
+        return commentPath.getParentPath();
+    }
+
+    public void delete() {
+        deleted = true;
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/repository/ArticleCommentCountRepository.java
+++ b/backend/comment/src/main/java/com/example/comment/repository/ArticleCommentCountRepository.java
@@ -1,0 +1,22 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.ArticleCommentCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleCommentCountRepository extends JpaRepository<ArticleCommentCount, Long> {
+
+    @Query(value = "update article_comment_count set comment_count = comment_count + 1 where article_id = :articleId",
+            nativeQuery = true)
+    @Modifying(clearAutomatically = true)
+    int increase(@Param("articleId") Long articleId);
+
+    @Query(value = "update article_comment_count set comment_count = comment_count - 1 where article_id = :articleId",
+            nativeQuery = true)
+    @Modifying(clearAutomatically = true)
+    int decrease(@Param("articleId") Long articleId);
+}

--- a/backend/comment/src/main/java/com/example/comment/repository/CommentRepository.java
+++ b/backend/comment/src/main/java/com/example/comment/repository/CommentRepository.java
@@ -1,0 +1,70 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query(value = " select comment.comment_id, comment.content, comment.parent_comment_id, comment.article_id, " +
+            " comment.writer_id, comment.deleted, comment.created_at " +
+            " from ( " +
+            "   select comment_id from comment where article_id = :articleId " +
+            "   order by parent_comment_id asc, comment_id asc " +
+            "   limit :limit offset :offset " +
+            " ) t left join comment on t.comment_id = comment.comment_id ",
+            nativeQuery = true)
+    List<Comment> findAll(@Param("articleId") Long articleId,
+                          @Param("offset") Long offset,
+                          @Param("limit") Long limit);
+
+    @Query(value = " select count(*) from ( " +
+            "   select comment_id from comment where article_id = :articleId limit :limit " +
+            " ) t ",
+            nativeQuery = true
+    )
+    Long count(@Param("articleId") Long articleId,
+               @Param("limit") Long limit);
+
+    @Query(value = " select comment.comment_id, comment.content, comment.parent_comment_id, comment.article_id, " +
+            " comment.writer_id, comment.deleted, comment.created_at " +
+            " from comment " +
+            " where article_id = :articleId " +
+            " order by parent_comment_id asc, comment_id asc " +
+            " limit :limit ",
+            nativeQuery = true)
+    List<Comment> findAllInfiniteScroll(@Param("articleId") Long articleId,
+                                        @Param("limit") Long limit);
+
+    @Query(value = " select comment.comment_id, comment.content, comment.parent_comment_id, comment.article_id, " +
+            " comment.writer_id, comment.deleted, comment.created_at " +
+            " from comment " +
+            " where article_id = :articleId and ( " +
+            "   parent_comment_id > :lastParentCommentId or " +
+            "   parent_comment_id = :lastParentCommentId and comment_id > :lastCommentId " +
+            ") " +
+            " order by parent_comment_id asc, comment_id asc " +
+            " limit :limit ",
+            nativeQuery = true)
+    List<Comment> findAllInfiniteScroll(@Param("articleId") Long articleId,
+                                        @Param("lastParentCommentId") Long lastParentCommentId,
+                                        @Param("lastCommentId") Long lastCommentId,
+                                        @Param("limit") Long limit);
+
+    @Query(
+            value = " select count(*) from ( " +
+                    "   select comment_id from comment " +
+                    "   where article_id = :articleId and parent_comment_id = :parentCommentId " +
+                    "   limit :limit " +
+                    " ) t",
+            nativeQuery = true
+    )
+    Long countBy(@Param("articleId") Long articleId,
+                 @Param("parentCommentId") Long parentCommentId,
+                 @Param("limit") Long limit);
+}

--- a/backend/comment/src/main/java/com/example/comment/repository/CommentRepositoryV2.java
+++ b/backend/comment/src/main/java/com/example/comment/repository/CommentRepositoryV2.java
@@ -1,0 +1,72 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.CommentV2;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CommentRepositoryV2 extends JpaRepository<CommentV2, Long> {
+
+    @Query(
+            value = "select * from comment_v2 where path = :path",
+            nativeQuery = true
+    )
+    Optional<CommentV2> findByPath(@Param("path") String path);
+
+    @Query(
+            value = " select path from comment_v2 " +
+                    " where article_id = :articleId and path > :pathPrefix and path like :pathPrefix% " +
+                    " order by path desc limit 1 ",
+            nativeQuery = true
+    )
+    Optional<String> findDescendantsTopPath(@Param("articleId") Long articleId, @Param("pathPrefix") String pathPrefix);
+
+    @Query(
+            value = " select comment_v2.comment_id, comment_v2.content, comment_v2.path, comment_v2.article_id, " +
+                    " comment_v2.writer_id, comment_v2.deleted, comment_v2.created_at " +
+                    " from ( " +
+                    "   select comment_id from comment_v2 where article_id = :articleId " +
+                    "   order by path asc " +
+                    "   limit :limit offset :offset " +
+                    " ) t left join comment_v2 on t.comment_id = comment_v2.comment_id ",
+            nativeQuery = true
+    )
+    List<CommentV2> findAll(@Param("articleId") Long articleId,
+                            @Param("offset") Long offset,
+                            @Param("limit") Long limit);
+
+    @Query(
+            value = " select count(*) from ( " +
+                    "   select comment_id from comment_v2 where article_id = :articleId limit :limit " +
+                    " ) c ",
+            nativeQuery = true
+    )
+    Long count(@Param("articleId") Long articleId, @Param("limit") Long aLong);
+
+    @Query(
+            value = " select comment_v2.comment_id, comment_v2.content, comment_v2.path, comment_v2.article_id, " +
+                    " comment_v2.writer_id, comment_v2.deleted, comment_v2.created_at " +
+                    " from comment_v2 " +
+                    " where article_id = :articleId " +
+                    " order by path asc " +
+                    " limit :limit ",
+            nativeQuery = true
+    )
+    List<CommentV2> findAllInfiniteScroll(@Param("articleId") Long articleId, @Param("limit") Long limit);
+
+    @Query(
+            value = " select comment_v2.comment_id, comment_v2.content, comment_v2.path, comment_v2.article_id, " +
+                    " comment_v2.writer_id, comment_v2.deleted, comment_v2.created_at " +
+                    " from comment_v2 " +
+                    " where article_id = :articleId and path > :lastPath " +
+                    " order by path asc " +
+                    " limit :limit ",
+            nativeQuery = true
+    )
+    List<CommentV2> findAllInfiniteScroll(@Param("articleId") Long articleId, @Param("lastPath") String lastPath, @Param("limit") Long pageSize);
+}

--- a/backend/comment/src/main/java/com/example/comment/service/CommentService.java
+++ b/backend/comment/src/main/java/com/example/comment/service/CommentService.java
@@ -1,0 +1,113 @@
+package com.example.comment.service;
+
+import com.example.comment.entity.ArticleCommentCount;
+import com.example.comment.entity.Comment;
+import com.example.comment.repository.ArticleCommentCountRepository;
+import com.example.comment.repository.CommentRepository;
+import com.example.comment.service.request.CommentCreateRequest;
+import com.example.comment.service.response.CommentPageResponse;
+import com.example.comment.service.response.CommentResponse;
+import com.example.snowflake.Snowflake;
+import com.example.support.PageLimitCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.function.Predicate.not;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final Snowflake snowflake = new Snowflake();
+    private final CommentRepository commentRepository;
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+
+    public CommentResponse create(CommentCreateRequest request) {
+        Comment parent = findParent(request);
+        Comment saved = commentRepository.save(
+                Comment.of(
+                        snowflake.nextId(),
+                        request.getContent(),
+                        parent == null ? null : parent.getParentCommentId(),
+                        request.getArticleId(),
+                        request.getWriterId()
+                )
+        );
+
+        int result = articleCommentCountRepository.increase(saved.getArticleId());
+        if(result == 0) {
+            articleCommentCountRepository.save(ArticleCommentCount.of(saved.getArticleId(), 1L));
+        }
+
+        return CommentResponse.from(saved);
+    }
+
+    private Comment findParent(CommentCreateRequest request) {
+        Long parentCommentId = request.getParentCommentId();
+        if (parentCommentId == null) {
+            return null;
+        }
+
+        return commentRepository.findById(parentCommentId)
+                .filter(not(Comment::getDeleted))
+                .filter(Comment::isRoot)
+                .orElseThrow();
+    }
+
+    @Transactional(readOnly = true)
+    public CommentResponse read(Long commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentPageResponse readAll(Long articleId, Long page, Long pageSize) {
+        List<Comment> comments = commentRepository.findAll(articleId, (page - 1) * pageSize, pageSize);
+        Long count = commentRepository.count(articleId, PageLimitCalculator.pageLimit(page, pageSize, 10L));
+
+        return CommentPageResponse.of(
+                comments.stream().map(CommentResponse::from).toList(),
+                count
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> readAllInfiniteScroll(Long articleId, Long lastParentCommentId, Long lastCommentId, Long limit) {
+        List<Comment> comments = (lastParentCommentId == null || lastCommentId == null)
+                ? commentRepository.findAllInfiniteScroll(articleId, limit)
+                : commentRepository.findAllInfiniteScroll(articleId, lastParentCommentId, lastCommentId, limit);
+
+        return comments.stream().map(CommentResponse::from).toList();
+    }
+
+    public void delete(Long commentId) {
+        commentRepository.findById(commentId)
+                .filter(not(Comment::getDeleted))
+                .ifPresent(comment -> {
+                    if (hasChildren(comment)) {
+                        comment.delete();
+                    } else {
+                        delete(comment);
+                    }
+                });
+    }
+
+    private boolean hasChildren(Comment comment) {
+        return commentRepository.countBy(comment.getArticleId(), comment.getCommentId(), 2L) == 2L;
+    }
+
+    private void delete(Comment comment) {
+        commentRepository.delete(comment);
+        articleCommentCountRepository.decrease(comment.getArticleId());
+        
+        if (!comment.isRoot()) {
+            commentRepository.findById(comment.getParentCommentId())
+                    .filter(Comment::getDeleted)
+                    .filter(not(this::hasChildren))
+                    .ifPresent(this::delete);
+        }
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/service/CommentServiceV2.java
+++ b/backend/comment/src/main/java/com/example/comment/service/CommentServiceV2.java
@@ -1,0 +1,114 @@
+package com.example.comment.service;
+
+import com.example.comment.entity.ArticleCommentCount;
+import com.example.comment.entity.CommentPath;
+import com.example.comment.entity.CommentV2;
+import com.example.comment.repository.ArticleCommentCountRepository;
+import com.example.comment.repository.CommentRepositoryV2;
+import com.example.comment.service.request.CommentCreateRequestV2;
+import com.example.comment.service.response.CommentPageResponseV2;
+import com.example.comment.service.response.CommentResponseV2;
+import com.example.snowflake.Snowflake;
+import com.example.support.PageLimitCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.function.Predicate.not;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentServiceV2 {
+    private final Snowflake snowflake = new Snowflake();
+    private final CommentRepositoryV2 commentRepository;
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+
+    public CommentResponseV2 create(CommentCreateRequestV2 request) {
+        CommentV2 parent = findParent(request);
+        CommentPath parentCommentPath = parent == null ? CommentPath.create("") : parent.getCommentPath();
+        String descendantsTopPath = commentRepository.findDescendantsTopPath(request.getArticleId(), parentCommentPath.getPath())
+                .orElse(null);
+
+        CommentV2 saved = commentRepository.save(
+                CommentV2.of(
+                        snowflake.nextId(),
+                        request.getContent(),
+                        request.getArticleId(),
+                        request.getWriterId(),
+                        parentCommentPath.createChildCommentPath(descendantsTopPath)
+                )
+       );
+
+        int result = articleCommentCountRepository.increase(request.getArticleId());
+        if(result == 0) {
+            articleCommentCountRepository.save(ArticleCommentCount.of(request.getArticleId(), 1L));
+        }
+
+        return CommentResponseV2.from(saved);
+    }
+
+    private CommentV2 findParent(CommentCreateRequestV2 request) {
+        return commentRepository.findByPath(request.getParentPath())
+                .filter(not(CommentV2::getDeleted))
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentResponseV2 read(Long commentId) {
+        return CommentResponseV2.from(commentRepository.findById(commentId).orElseThrow());
+    }
+
+    @Transactional(readOnly = true)
+    public CommentPageResponseV2 readAll(Long articleId, Long page, Long pageSize) {
+        List<CommentV2> comments = commentRepository.findAll(articleId, (page - 1) * pageSize, pageSize);
+        Long commentCount = commentRepository.count(articleId, PageLimitCalculator.pageLimit(page, pageSize, 10L));
+
+        return CommentPageResponseV2.of(
+                comments.stream().map(CommentResponseV2::from).toList(),
+                commentCount
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponseV2> readAllInfiniteScroll(Long articleId, String lastPath, Long pageSize) {
+       List<CommentV2> comments = (lastPath == null)
+               ? commentRepository.findAllInfiniteScroll(articleId, pageSize)
+               : commentRepository.findAllInfiniteScroll(articleId, lastPath, pageSize);
+
+       return comments.stream()
+               .map(CommentResponseV2::from)
+               .toList();
+    }
+
+    public void delete(Long commentId) {
+        commentRepository.findById(commentId)
+                .filter(not(CommentV2::getDeleted))
+                .ifPresent(comment -> {
+                    if(hasChildren(comment)) {
+                        comment.delete();
+                    } else {
+                        delete(comment);
+                    }
+                });
+    }
+
+    private boolean hasChildren(CommentV2 comment) {
+        return commentRepository.findDescendantsTopPath(comment.getArticleId(), comment.getPath())
+                .isPresent();
+    }
+
+    private void delete(CommentV2 comment) {
+        commentRepository.delete(comment);
+        articleCommentCountRepository.decrease(comment.getArticleId());
+
+        if(!comment.isRoot()) {
+            commentRepository.findByPath(comment.getCommentPath().getParentPath())
+                    .filter(CommentV2::getDeleted)
+                    .filter(not(this::hasChildren))
+                    .ifPresent(this::delete);
+        }
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/service/request/CommentCreateRequest.java
+++ b/backend/comment/src/main/java/com/example/comment/service/request/CommentCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.comment.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCreateRequest {
+    private Long articleId;
+    private String content;
+    private Long parentCommentId;
+    private Long writerId;
+}

--- a/backend/comment/src/main/java/com/example/comment/service/request/CommentCreateRequestV2.java
+++ b/backend/comment/src/main/java/com/example/comment/service/request/CommentCreateRequestV2.java
@@ -1,0 +1,13 @@
+package com.example.comment.service.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCreateRequestV2 {
+    private Long articleId;
+    private String content;
+    private String parentPath;
+    private Long writerId;
+}

--- a/backend/comment/src/main/java/com/example/comment/service/response/CommentPageResponse.java
+++ b/backend/comment/src/main/java/com/example/comment/service/response/CommentPageResponse.java
@@ -1,0 +1,19 @@
+package com.example.comment.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentPageResponse {
+    private List<CommentResponse> comments;
+    private Long commentCount;
+
+    public static CommentPageResponse of(List<CommentResponse> comments, Long commentCount) {
+        return new CommentPageResponse(comments, commentCount);
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/service/response/CommentPageResponseV2.java
+++ b/backend/comment/src/main/java/com/example/comment/service/response/CommentPageResponseV2.java
@@ -1,0 +1,19 @@
+package com.example.comment.service.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentPageResponseV2 {
+    private List<CommentResponseV2> comments;
+    private Long commentCount;
+
+    public static CommentPageResponseV2 of(List<CommentResponseV2> comments, Long commentCount) {
+        return new CommentPageResponseV2(comments, commentCount);
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/service/response/CommentResponse.java
+++ b/backend/comment/src/main/java/com/example/comment/service/response/CommentResponse.java
@@ -1,0 +1,33 @@
+package com.example.comment.service.response;
+
+import com.example.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponse {
+    private Long commentId;
+    private String content;
+    private Long parentCommentId;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment) {
+        CommentResponse response = new CommentResponse();
+        response.commentId = comment.getCommentId();
+        response.content = comment.getContent();
+        response.parentCommentId = comment.getParentCommentId();
+        response.articleId = comment.getArticleId();
+        response.writerId = comment.getWriterId();
+        response.deleted = comment.getDeleted();
+        response.createdAt = comment.getCreatedAt();
+        return response;
+    }
+}

--- a/backend/comment/src/main/java/com/example/comment/service/response/CommentResponseV2.java
+++ b/backend/comment/src/main/java/com/example/comment/service/response/CommentResponseV2.java
@@ -1,0 +1,34 @@
+package com.example.comment.service.response;
+
+import com.example.comment.entity.CommentV2;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponseV2 {
+    private Long commentId;
+    private String content;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private String path;
+    private LocalDateTime createdAt;
+
+    public static CommentResponseV2 from(CommentV2 comment) {
+        CommentResponseV2 response = new CommentResponseV2();
+        response.commentId = comment.getCommentId();
+        response.content = comment.getContent();
+        response.articleId = comment.getArticleId();
+        response.writerId = comment.getWriterId();
+        response.deleted = comment.getDeleted();
+        response.path = comment.getCommentPath().getPath();
+        response.createdAt = comment.getCreatedAt();
+
+        return response;
+    }
+}

--- a/backend/comment/src/test/java/com/example/comment/controller/CommentControllerTest.java
+++ b/backend/comment/src/test/java/com/example/comment/controller/CommentControllerTest.java
@@ -1,0 +1,150 @@
+package com.example.comment.controller;
+
+import com.example.comment.entity.Comment;
+import com.example.comment.repository.CommentRepository;
+import com.example.comment.service.request.CommentCreateRequest;
+import com.example.comment.service.response.CommentResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @BeforeEach
+    void setUp() {
+        List<Comment> roots = new ArrayList<>();
+        for (int g = 0; g < 10; g++) {
+            int i = g * 10 + 1;
+            roots.add(of((long) i, null));
+        }
+
+        List<Comment> childs = new ArrayList<>();
+        for (Comment root : roots) {
+            Long parent = root.getCommentId();
+            for (int i = 1; i <= 9; i++) {
+                childs.add(of(parent + i, parent));
+            }
+        }
+        commentRepository.saveAll(roots);
+        commentRepository.saveAll(childs);
+        commentRepository.flush();
+    }
+
+    private static Comment of(Long commentId, Long parentCommentId) {
+        return Comment.of(commentId, "콘텐츠" + commentId, parentCommentId, 1L, 1L);
+    }
+
+    @DisplayName("신규 생성된 comment는 commentId와 parentCommentId가 같다")
+    @Test
+    void create() throws Exception {
+        CommentCreateRequest request = new CommentCreateRequest(1L, "내용없음", null, 1L);
+
+        MvcResult mvcResult = mockMvc.perform(post("/v1/comment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                ).andExpect(status().isCreated())
+                .andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+        CommentResponse commentResponse = objectMapper.readValue(contentAsString, CommentResponse.class);
+
+        assertThat(commentResponse.getCommentId()).isEqualTo(commentResponse.getParentCommentId());
+    }
+
+    @Test
+    void read() throws Exception {
+        mockMvc.perform(get("/v1/comment/{commentId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.commentId").value(1L));
+    }
+
+    @Test
+    void readAll() throws Exception {
+        mockMvc.perform(get("/v1/comment")
+                .param("articleId", "1")
+                .param("page", "1")
+                .param("pageSize", "10")
+        ).andExpectAll(status().isOk(),
+                jsonPath("$.comments.size()").value(10),
+                jsonPath("$.commentCount").value(100) // 101개가 되야 다음 버튼 표출
+        );
+    }
+
+    @DisplayName("처음 조회시 가장 오래된 순으로 pageSize 만큼 조회한다")
+    @Test
+    void firstReadAllInfiniteScroll() throws Exception {
+        mockMvc.perform(get("/v1/comment/infinite-scroll")
+                .param("articleId", "1")
+                .param("lastParentCommentId", "")
+                .param("lastCommentId", "")
+                .param("pageSize", "10")
+        ).andExpectAll(
+                status().isOk(),
+                jsonPath("$.size()").value(10)
+        );
+    }
+
+    @DisplayName("오름차순 기준으로 두번째 대댓글 그룹 10개를 조회한다")
+    @Test
+    void secondReadAllInfiniteScroll() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/v1/comment/infinite-scroll")
+                        .param("articleId", "1")
+                        .param("lastParentCommentId", "1")
+                        .param("lastCommentId", "10")
+                        .param("pageSize", "10")
+                ).andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+
+        List<CommentResponse> commentResponses = objectMapper.readValue(contentAsString, new TypeReference<>() {
+        });
+        assertThat(commentResponses).hasSize(10);
+        assertThat(commentResponses).extracting(CommentResponse::getParentCommentId)
+                .containsOnly(11L);
+    }
+
+    @DisplayName("부모 댓글을 삭제할 때, 자식 댓글이 있으면 논리 삭제를 한다")
+    @Test
+    void delete() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/v1/comment/{commentId}", 1L))
+                .andExpect(status().isNoContent());
+    }
+
+}

--- a/backend/comment/src/test/java/com/example/comment/controller/CommentControllerV2Test.java
+++ b/backend/comment/src/test/java/com/example/comment/controller/CommentControllerV2Test.java
@@ -1,0 +1,179 @@
+package com.example.comment.controller;
+
+import com.example.comment.entity.CommentPath;
+import com.example.comment.entity.CommentV2;
+import com.example.comment.repository.CommentRepositoryV2;
+import com.example.comment.service.request.CommentCreateRequestV2;
+import com.example.comment.service.response.CommentPageResponseV2;
+import com.example.comment.service.response.CommentResponseV2;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class CommentControllerV2Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CommentRepositoryV2 commentRepository;
+
+    /*
+       샘플 데이터 (1depth : 00000 ~ 00009, 2depth: 각 10개씩, 총 11 * 10 = 110개)
+       00000
+           0000000000
+           0000000001
+           0000000002
+           0000000003
+           0000000004
+           0000000005
+           0000000006
+           0000000007
+           0000000008
+           0000000009
+    */
+    @BeforeEach
+    void setUp() {
+        List<CommentV2> comments = new ArrayList<>();
+        rec(0, comments, CommentPath.create(""));
+
+        commentRepository.saveAll(comments);
+        commentRepository.flush();
+    }
+
+    private void rec(int depth, List<CommentV2> comments, CommentPath path) {
+        if(depth == 2) {
+            return;
+        }
+
+        String descendantsTopPath = null;
+        for(int i = 1; i <= 10; i++) {
+            CommentPath childPath = path.createChildCommentPath(descendantsTopPath);
+            comments.add(of(childPath));
+
+            rec(depth + 1, comments, childPath);
+
+            descendantsTopPath = childPath.getPath();
+        }
+    }
+
+    private final AtomicLong commentIdGenerator = new AtomicLong(0L);
+    private CommentV2 of(CommentPath commentPath) {
+        return CommentV2.of(commentIdGenerator.incrementAndGet(), "콘텐츠", 1L, 1L, commentPath);
+    }
+
+    @Test
+    void create() throws Exception {
+        CommentCreateRequestV2 request = new CommentCreateRequestV2(1L, "콘텐츠", "", 1L); // 마지막 path 00009 00009
+
+        mockMvc.perform(post("/v2/comment")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.path").value("0000A")); // 0 ~ 9, A-Z, a-z
+    }
+
+    @Test
+    void read() throws Exception {
+        Long commentId = 1L;
+
+        mockMvc.perform(get("/v2/comment/{commentId}", commentId))
+                .andExpectAll(status().isOk(),
+                        jsonPath("$.commentId").value(commentId),
+                        jsonPath("$.path").value("00000"));
+    }
+
+    @Test
+    void readAll() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/v2/comment")
+                        .param("articleId", "1")
+                        .param("page", "1")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+        CommentPageResponseV2 comments = objectMapper.readValue(contentAsString, new TypeReference<>(){});
+
+        assertThat(comments.getCommentCount()).isEqualTo(101L);
+        assertThat(comments.getComments()).extracting(CommentResponseV2::getPath)
+                .allMatch(path -> path.startsWith("00000")); // 00000 ~ 00000 00009
+    }
+
+    @Test
+    void readAllInfiniteScrollWhenFirst() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/v2/comment/infinite-scroll")
+                        .param("articleId", "1")
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+        List<CommentResponseV2> comments = objectMapper.readValue(contentAsString, new TypeReference<>(){});
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(CommentResponseV2::getPath)
+                .allMatch(path -> path.startsWith("00000")); // 00000 ~ 00000 00009
+    }
+
+    @Test
+    void readAllInfiniteScrollWhenSecond() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/v2/comment/infinite-scroll")
+                        .param("articleId", "1")
+                        .param("lastPath", "0000000009") // 테스트 편의 위해
+                        .param("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+        List<CommentResponseV2> comments = objectMapper.readValue(contentAsString, new TypeReference<>(){});
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(CommentResponseV2::getPath)
+                .allMatch(path -> path.startsWith("00001")); // 00001 ~ 00001 00009
+    }
+
+    @Test
+    void delete() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/v2/comment/{commentId}", 1L))
+                .andExpect(status().isNoContent());
+
+        Optional<CommentV2> comment = commentRepository.findById(1L);
+
+        assertThat(comment).isPresent();
+        assertThat(comment.get()).extracting(CommentV2::getDeleted)
+                .isEqualTo(true);
+    }
+}

--- a/backend/comment/src/test/java/com/example/comment/entity/CommentPathTest.java
+++ b/backend/comment/src/test/java/com/example/comment/entity/CommentPathTest.java
@@ -1,0 +1,52 @@
+package com.example.comment.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommentPathTest {
+
+    @Test
+    void create() {
+        // 00000 생성
+        assertCommentPath(CommentPath.create(""), null, "00000");
+
+        // 00000
+        // 00001 생성
+        assertCommentPath(CommentPath.create(""), "00000", "00001");
+
+        // 00000
+        //       00000 생성
+        assertCommentPath(CommentPath.create("00000"), null, "0000000000");
+
+        // 0000z
+        //       abcdz
+        //            zzzzz
+        //                 zzzzz
+        //       abce0 생성
+        assertCommentPath(CommentPath.create("0000z"), "0000zabcdzzzzzzzzzzz", "0000zabce0");
+    }
+
+    void assertCommentPath(CommentPath parentPath, String descendantsTopPath, String expected) {
+        CommentPath childCommentPath = parentPath.createChildCommentPath(descendantsTopPath);
+
+        assertThat(childCommentPath).isEqualTo(CommentPath.create(expected));
+    }
+
+    @Test
+    void createChildCommentPathIfMaxDepth() {
+        CommentPath commentPath = CommentPath.create("zzzzz".repeat(5));
+
+        assertThatThrownBy(() -> commentPath.createChildCommentPath(null))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void createChildCommentPathIfChunkOverflow() {
+        CommentPath commentPath = CommentPath.create("");
+
+        assertThatThrownBy(() -> commentPath.createChildCommentPath("zzzzz"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/backend/comment/src/test/java/com/example/comment/repository/ArticleCommentCountRepositoryTest.java
+++ b/backend/comment/src/test/java/com/example/comment/repository/ArticleCommentCountRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.ArticleCommentCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class ArticleCommentCountRepositoryTest {
+    @Autowired
+    private ArticleCommentCountRepository articleCommentCountRepository;
+
+    @BeforeEach
+    void setUp() {
+        articleCommentCountRepository.save(new ArticleCommentCount(1L, 10L));
+    }
+
+    @Test
+    void increaseSuccess() {
+        long articleId = 1L;
+
+        int result = articleCommentCountRepository.increase(articleId);
+        Long count = articleCommentCountRepository.findById(articleId).map(ArticleCommentCount::getCommentCount).orElseThrow();
+
+        assertThat(result).isEqualTo(1);
+        assertThat(count).isEqualTo(11L);
+    }
+
+    @Test
+    void increaseFail() {
+        long articleId = 99L;
+
+        int result = articleCommentCountRepository.increase(articleId);
+
+        assertThat(result).isZero();
+    }
+
+    @Test
+    void decreaseSuccess() {
+        long articleId = 1L;
+
+        int result = articleCommentCountRepository.decrease(articleId);
+        Long count = articleCommentCountRepository.findById(articleId).map(ArticleCommentCount::getCommentCount).orElseThrow();
+
+        assertThat(result).isEqualTo(1);
+        assertThat(count).isEqualTo(9L);
+    }
+
+    @Test
+    void decreaseFail() {
+        long articleId = 99L;
+
+        int result = articleCommentCountRepository.decrease(articleId);
+
+        assertThat(result).isEqualTo(0);
+    }
+}

--- a/backend/comment/src/test/java/com/example/comment/repository/CommentRepositoryTest.java
+++ b/backend/comment/src/test/java/com/example/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.Comment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest(showSql = false)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        List<Comment> roots = new ArrayList<>();
+        for (int g = 0; g < 10; g++) {
+            int i = g * 10 + 1;
+            roots.add(of((long) i, null));
+        }
+
+        List<Comment> childs = new ArrayList<>();
+        for (Comment root : roots) {
+            Long parent = root.getCommentId();
+            for (int i = 1; i <= 9; i++) {
+                childs.add(of(parent + i, parent));
+            }
+        }
+        commentRepository.saveAll(roots);
+        commentRepository.saveAll(childs);
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private static Comment of(Long commentId, Long parentCommentId) {
+        return Comment.of(commentId, "콘텐츠" + commentId, parentCommentId, 1L, 1L);
+    }
+
+    @Test
+    void findAll() {
+        List<Comment> comments = commentRepository.findAll(1L, 0L, 10L);
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(Comment::getParentCommentId)
+                .containsOnly(1L);
+    }
+
+    @Test
+    void count() {
+        Long count = commentRepository.count(1L, 101L); // 101까지 있어야 페이징에 다음 버튼 출력
+
+        assertThat(count).isEqualTo(100L);
+    }
+
+    @Test
+    void findAllInfiniteScrollWhenFirst() {
+        List<Comment> comments = commentRepository.findAllInfiniteScroll(1L, 10L);
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(Comment::getParentCommentId)
+                .containsOnly(1L);
+    }
+
+    @Test
+    void findAllInfiniteScrollWhenNext() {
+        List<Comment> comments = commentRepository.findAllInfiniteScroll(1L, 1L, 10L, 10L);
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(Comment::getParentCommentId)
+                .containsOnly(11L);
+    }
+
+    @Test
+    void findAllInfiniteScrollWhenSameParentCommentId() {
+        // 5개씩 조회했을 때
+        List<Comment> comments = commentRepository.findAllInfiniteScroll(1L, 1L, 5L, 5L);
+
+        assertThat(comments).hasSize(5);
+        assertThat(comments).extracting(Comment::getParentCommentId)
+                .containsOnly(1L);
+    }
+
+    @DisplayName("부모와 자식 댓글이 2개 있는지 확인한다")
+    @Test
+    void countBy() {
+        Long count = commentRepository.countBy(1L, 1L, 2L);
+
+        assertThat(count).isEqualTo(2L);
+    }
+
+    @DisplayName("존재하지 않는 parentCommentId로 조회하면 0을 반환한다")
+    @Test
+    void countByWhenUnknownComment() {
+        Long count = commentRepository.countBy(1L, 101L, 2L);
+
+        assertThat(count).isEqualTo(0L);
+    }
+}

--- a/backend/comment/src/test/java/com/example/comment/repository/CommentRepositoryV2Test.java
+++ b/backend/comment/src/test/java/com/example/comment/repository/CommentRepositoryV2Test.java
@@ -1,0 +1,142 @@
+package com.example.comment.repository;
+
+import com.example.comment.entity.CommentPath;
+import com.example.comment.entity.CommentV2;
+import com.example.snowflake.Snowflake;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest(showSql = false)
+class CommentRepositoryV2Test {
+
+    private final Snowflake snowflake = new Snowflake();
+
+    @Autowired
+    private CommentRepositoryV2 commentRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+     /*
+        샘플 데이터 (1depth : 00000 ~ 00009, 2depth: 각 10개씩, 총 11 * 10 = 110개)
+        00000
+            0000000000
+            0000000001
+            0000000002
+            0000000003
+            0000000004
+            0000000005
+            0000000006
+            0000000007
+            0000000008
+            0000000009
+     */
+    @BeforeEach
+    void setUp() {
+        List<CommentV2> comments = new ArrayList<>();
+
+        rec(0, comments, CommentPath.create(""));
+
+        commentRepository.saveAll(comments);
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private void rec(int depth, List<CommentV2> comments, CommentPath path) {
+        if(depth == 2) {
+            return;
+        }
+
+        String descendantsTopPath = null;
+        for(int i = 1; i <= 10; i++) {
+            CommentPath childPath = path.createChildCommentPath(descendantsTopPath);
+            comments.add(of(childPath));
+
+            rec(depth + 1, comments, childPath);
+
+            descendantsTopPath = childPath.getPath();
+        }
+    }
+
+    private CommentV2 of(CommentPath commentPath) {
+        return CommentV2.of(snowflake.nextId(), "콘텐츠", 1L, 1L, commentPath);
+    }
+
+    @Test
+    void findByPath() {
+        String path = "00000".repeat(2);
+        Optional<CommentV2> comment = commentRepository.findByPath(path);
+
+        assertThat(comment).isPresent();
+    }
+
+    @Test
+    void findByPathWhenNotFound() {
+        String path = "zzzzz".repeat(5);
+        Optional<CommentV2> comment = commentRepository.findByPath(path);
+
+        assertThat(comment).isEmpty();
+    }
+
+    @Test
+    void findDescendantsTopPath() {
+        String pathPrefix = "00000";
+        Optional<String> descendantsTopPath = commentRepository.findDescendantsTopPath(1L, pathPrefix);
+
+        assertThat(descendantsTopPath).isPresent();
+        assertThat(descendantsTopPath.get()).isEqualTo("0000000009");
+    }
+
+    @Test
+    void findDescendantsTopPathWhenNotFound() {
+        String pathPrefix = "00009000010"; // 마지막 : 00009 00009
+        Optional<String> descendantsTopPath = commentRepository.findDescendantsTopPath(1L, pathPrefix);
+
+        assertThat(descendantsTopPath).isEmpty();
+    }
+
+    @Test
+    void findAll() {
+        List<CommentV2> comments = commentRepository.findAll(1L, 0L, 10L);
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(CommentV2::getPath)
+                .allMatch(path -> path.startsWith("00000"));
+    }
+
+    @Test
+    void count() {
+        Long count = commentRepository.count(1L, 101L);
+
+        assertThat(count).isEqualTo(101L);
+    }
+
+    @Test
+    void findAllInfiniteScrollWhenFirst() {
+        List<CommentV2> comments = commentRepository.findAllInfiniteScroll(1L, 10L);
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(CommentV2::getPath)
+                .allMatch(path -> path.startsWith("00000"));
+    }
+
+    @Test
+    void findAllInfiniteScrollWhenSecond() {
+        List<CommentV2> comments = commentRepository.findAllInfiniteScroll(1L, "0000000009", 10L); // 테스트 편의를 위해 lastPath = 00000 00009 지정
+
+        assertThat(comments).hasSize(10);
+        assertThat(comments).extracting(CommentV2::getPath)
+                .allMatch(path -> path.startsWith("00001"));
+    }
+}

--- a/backend/comment/src/test/resources/application-test.yml
+++ b/backend/comment/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+    defer-datasource-initialization: true

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -1,3 +1,6 @@
+-- article 유저 권한 부여 필요
+create database article;
+
 create table article (
      article_id bigint not null primary key,
      title varchar(100) not null,
@@ -10,7 +13,46 @@ create table article (
 
 create index idx_board_id_article_id on article(board_id asc, article_id desc);
 
+-- board의 article 개수
 create table board_article_count (
      board_id bigint not null primary key,
      article_count bigint not null
+);
+
+-- 인접리스트 방식의 댓글
+-- comment 유저 권한 부여 필요
+create table comment (
+     comment_id bigint not null primary key,
+     content varchar(3000) not null,
+     article_id bigint not null,
+     parent_comment_id bigint not null,
+     writer_id bigint not null,
+     deleted bool not null,
+     created_at datetime not null
+);
+
+create index idx_article_id_parent_comment_id_comment_id on comment (
+     article_id asc, parent_comment_id asc, comment_id asc
+);
+
+-- path 방식의 댓글
+-- utf8mb4_bin 대소문자 구분
+create table comment_v2 (
+    comment_id bigint not null primary key,
+    content varchar(3000) not null,
+    article_id bigint not null,
+    writer_id bigint not null,
+    path varchar(25) character set utf8mb4 collate utf8mb4_bin not null,
+    deleted bool not null,
+    created_at datetime not null
+);
+
+create unique index idx_article_id_path on comment_v2 (
+    article_id asc, path asc
+);
+
+-- article의 댓글 수
+create table article_comment_count (
+   article_id bigint not null primary key,
+   comment_count bigint not null
 );


### PR DESCRIPTION
![스크린샷 2025-07-03 15-11-52](https://github.com/user-attachments/assets/3fb6b435-02bb-445a-85ca-9a3f66fbdac5)

- `comment` : 2depth, 인접리스트 방식 
  - comment_parent_id 사용해서 계층 구조 나타냄
  - 루트인 경우 `comment_parent_id == comment_id`
  - 삭제할 경우 자식이 있으면 논리적인 삭제(`deleted = true`) 표시하고, 자식이 없으면 물리적 삭제
- `comment_v2` : 무한 depth, path 열거형 방식
  - path : varchar(25)로 문자열 25개로 구성, 5개씩 나눠서 5depth까지 제한
  - 각 자리수는 0~9, A-Z, a-z 중 하나의 값으로 구성
- `article_comment_count` : 게시글 별로 댓글 개수 카운팅



