### PR TITLE
article view count

### DIFF
--- a/backend/view/build.gradle
+++ b/backend/view/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    runtimeOnly 'com.h2database:h2'
+    testImplementation 'com.github.codemonstur:embedded-redis:1.0.0'
+
+    implementation project(':backend:common:snowflake')
 }

--- a/backend/view/src/main/java/com/example/view/config/RedisConfiguration.java
+++ b/backend/view/src/main/java/com/example/view/config/RedisConfiguration.java
@@ -1,0 +1,23 @@
+package com.example.view.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+}

--- a/backend/view/src/main/java/com/example/view/controller/ArticleViewController.java
+++ b/backend/view/src/main/java/com/example/view/controller/ArticleViewController.java
@@ -1,0 +1,25 @@
+package com.example.view.controller;
+
+import com.example.view.service.ArticleViewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ArticleViewController {
+    private final ArticleViewService articleViewService;
+
+    @PostMapping("/v1/article-view/article/{articleId}/user/{userId}")
+    public ResponseEntity<Long> increase(@PathVariable("articleId") Long articleId, @PathVariable("userId") Long userId) {
+        return ResponseEntity.ok(articleViewService.increase(articleId, userId));
+    }
+
+    @GetMapping("/v1/article_view/article/{articleId}/count")
+    public ResponseEntity<Long> count(@PathVariable("articleId") Long articleId) {
+        return ResponseEntity.ok(articleViewService.count(articleId));
+    }
+}

--- a/backend/view/src/main/java/com/example/view/entity/ArticleViewCount.java
+++ b/backend/view/src/main/java/com/example/view/entity/ArticleViewCount.java
@@ -1,0 +1,25 @@
+package com.example.view.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "article_view_count")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleViewCount {
+    @Id
+    private Long articleId;
+    private Long viewCount;
+
+    public static ArticleViewCount of(Long articleId, Long viewCount) {
+        ArticleViewCount articleViewCount = new ArticleViewCount();
+        articleViewCount.articleId = articleId;
+        articleViewCount.viewCount = viewCount;
+        return articleViewCount;
+    }
+}

--- a/backend/view/src/main/java/com/example/view/repository/ArticleViewCountBackUpRepository.java
+++ b/backend/view/src/main/java/com/example/view/repository/ArticleViewCountBackUpRepository.java
@@ -1,0 +1,21 @@
+package com.example.view.repository;
+
+import com.example.view.entity.ArticleViewCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleViewCountBackUpRepository extends JpaRepository<ArticleViewCount, Long> {
+
+    @Query(value = " update article_view_count set view_count = :viewCount " +
+            " where article_id = :articleId and view_count < :viewCount",
+            nativeQuery = true)
+    @Modifying
+    int updateViewCount(
+            @Param("articleId") Long articleId,
+            @Param("viewCount") Long viewCount
+    );
+}

--- a/backend/view/src/main/java/com/example/view/repository/ArticleViewCountRepository.java
+++ b/backend/view/src/main/java/com/example/view/repository/ArticleViewCountRepository.java
@@ -1,0 +1,30 @@
+package com.example.view.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewCountRepository {
+    private static final String KEY_FORMAT = "article::%s::view_count";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Long read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return result == null ? 0L : Long.parseLong(result);
+    }
+
+    public Long increase(Long articleId) {
+        return redisTemplate.opsForValue().increment(generateKey(articleId));
+    }
+
+    public void set(Long articleId, Long viewCount) {
+        redisTemplate.opsForValue().set(generateKey(articleId), String.valueOf(viewCount));
+    }
+
+    private String generateKey(Long articleId) {
+        return String.format(KEY_FORMAT, articleId);
+    }
+}

--- a/backend/view/src/main/java/com/example/view/repository/ArticleViewDistributedLockRepository.java
+++ b/backend/view/src/main/java/com/example/view/repository/ArticleViewDistributedLockRepository.java
@@ -1,0 +1,25 @@
+package com.example.view.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+// 조회수 어뷰징 방지 (10s)
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewDistributedLockRepository {
+    private static final String KEY_FORMAT = "view::article::%s::user::%s::lock";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Boolean lock(Long articleId, Long userId, Duration ttl) {
+        String key = generateKey(articleId, userId);
+        return redisTemplate.opsForValue().setIfAbsent(key, "", ttl);
+    }
+
+    private String generateKey(Long articleId, Long userId) {
+        return KEY_FORMAT.formatted(articleId, userId);
+    }
+}

--- a/backend/view/src/main/java/com/example/view/service/ArticleViewCountBackUpProcessor.java
+++ b/backend/view/src/main/java/com/example/view/service/ArticleViewCountBackUpProcessor.java
@@ -1,0 +1,28 @@
+package com.example.view.service;
+
+import com.example.view.entity.ArticleViewCount;
+import com.example.view.repository.ArticleViewCountBackUpRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleViewCountBackUpProcessor {
+
+    private final ArticleViewCountBackUpRepository articleViewCountBackUpRepository;
+
+    @Transactional
+    public void backUp(Long articleId, Long count) {
+        int result = articleViewCountBackUpRepository.updateViewCount(articleId, count);
+        if (result == 0) {
+            articleViewCountBackUpRepository.findById(articleId)
+                    .ifPresentOrElse(
+                            ignored -> {
+                            },
+                            () -> articleViewCountBackUpRepository.save(ArticleViewCount.of(articleId, count))
+                    );
+        }
+    }
+
+}

--- a/backend/view/src/main/java/com/example/view/service/ArticleViewService.java
+++ b/backend/view/src/main/java/com/example/view/service/ArticleViewService.java
@@ -1,0 +1,36 @@
+package com.example.view.service;
+
+import com.example.view.repository.ArticleViewCountRepository;
+import com.example.view.repository.ArticleViewDistributedLockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleViewService {
+    private static final int BACK_UP_BATCH_SIZE = 1000;
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final ArticleViewCountRepository articleViewCountRepository;
+    private final ArticleViewCountBackUpProcessor articleViewCountBackUpProcessor;
+    private final ArticleViewDistributedLockRepository articleViewDistributedLockRepository;
+
+    public Long increase(Long articleId, Long userId) {
+        if (!articleViewDistributedLockRepository.lock(articleId, userId, TTL)) {
+            return count(articleId);
+        }
+
+        Long count = articleViewCountRepository.increase(articleId);
+        if (count % BACK_UP_BATCH_SIZE == 0) {
+            articleViewCountBackUpProcessor.backUp(articleId, count);
+        }
+
+        return count;
+    }
+
+    public Long count(Long articleId) {
+        return articleViewCountRepository.read(articleId);
+    }
+}

--- a/backend/view/src/main/resources/application.yml
+++ b/backend/view/src/main/resources/application.yml
@@ -3,3 +3,8 @@ server:
 spring:
   application:
     name: article-view-service
+  data:
+    redis:
+      host: localhost
+      port: 6379
+

--- a/backend/view/src/test/java/com/example/view/EmbeddedRedis.java
+++ b/backend/view/src/test/java/com/example/view/EmbeddedRedis.java
@@ -1,0 +1,78 @@
+package com.example.view;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import redis.embedded.RedisServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// reference : https://jojoldu.tistory.com/297
+@TestConfiguration
+public class EmbeddedRedis {
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void start() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : redisPort;
+        this.redisServer = new RedisServer(port);
+        this.redisServer.start();
+    }
+
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(redisPort));
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null) {
+            this.redisServer.stop();
+        }
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+        for(int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if(!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN | grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try(BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+        } catch (Exception e) {}
+
+        String result = pidInfo.toString();
+        return !result.isEmpty();
+    }
+}

--- a/backend/view/src/test/java/com/example/view/controller/ArticleViewControllerTest.java
+++ b/backend/view/src/test/java/com/example/view/controller/ArticleViewControllerTest.java
@@ -1,0 +1,98 @@
+package com.example.view.controller;
+
+import com.example.view.EmbeddedRedis;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Import(EmbeddedRedis.class)
+class ArticleViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        Collection<String> redisKey = redisTemplate.keys("*");
+        if (redisKey != null && !redisKey.isEmpty()) {
+            redisTemplate.delete(redisKey);
+        }
+    }
+
+    @Test
+    void increaseWhenFirstView() throws Exception {
+        assertArticleViewCount(requestIncrease(1L, 1L), 1L);
+    }
+
+    @Test
+    void increase() throws Exception {
+        long articleId = 1L;
+        redisTemplate.opsForValue().set(articleViewCountKey(articleId), "100");
+
+        assertArticleViewCount(requestIncrease(articleId, 1L), 101L);
+    }
+
+    @Test
+    void readWhenNoneExistArticleViewCount() throws Exception {
+        assertArticleViewCount(requestRead(1L), 0L);
+    }
+
+    @Test
+    void read() throws Exception {
+        Long articleId = 1L;
+        redisTemplate.opsForValue().set(articleViewCountKey(articleId), "100");
+
+        assertArticleViewCount(requestRead(articleId), 100L);
+    }
+
+    String articleViewCountKey(Long articleId) {
+        return String.format("article::%s::view_count", articleId);
+    }
+
+    MvcResult requestIncrease(long articleId, long userId) throws Exception {
+        return mockMvc.perform(post("/v1/article-view/article/{articleId}/user/{userId}", articleId, userId))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    MvcResult requestRead(Long articleId) throws Exception {
+        return mockMvc.perform(get("/v1/article_view/article/{articleId}/count", articleId))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    void assertArticleViewCount(MvcResult mvcResult, long expected) throws UnsupportedEncodingException, JsonProcessingException {
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String contentAsString = response.getContentAsString();
+        Long count = objectMapper.readValue(contentAsString, Long.class);
+
+        assertThat(count).isEqualTo(expected);
+    }
+}

--- a/backend/view/src/test/java/com/example/view/service/ArticleViewServiceTest.java
+++ b/backend/view/src/test/java/com/example/view/service/ArticleViewServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.view.service;
+
+import com.example.view.EmbeddedRedis;
+import com.example.view.entity.ArticleViewCount;
+import com.example.view.repository.ArticleViewCountBackUpRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Import(EmbeddedRedis.class)
+class ArticleViewServiceTest {
+    @Autowired
+    private ArticleViewService articleViewService;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ArticleViewCountBackUpRepository articleViewCountBackUpRepository;
+
+    @BeforeEach
+    void setUp() {
+        try(RedisConnection connection = stringRedisTemplate.getConnectionFactory().getConnection()) {
+            connection.serverCommands().flushAll();
+        }
+    }
+
+    String articleViewCountKey(Long articleId) {
+        return String.format("article::%s::view_count", articleId);
+    }
+
+    String articleViewDistributedLockKey(Long articleId, Long userId) {
+        return String.format("view::article::%s::user::%s::lock", articleId, userId);
+    }
+
+    @Test
+    void increaseWithoutLock() {
+        stringRedisTemplate.opsForValue().set(articleViewCountKey(1L), "99");
+
+        Long result = articleViewService.increase(1L, 1L);
+
+        assertThat(result).isEqualTo(100L);
+    }
+
+    @Test
+    void increaseWithLock() {
+        stringRedisTemplate.opsForValue().set(articleViewCountKey(1L), "1");
+        stringRedisTemplate.opsForValue().set(articleViewDistributedLockKey(1L, 1L), "");
+
+        Long result = articleViewService.increase(1L, 1L);
+
+        assertThat(result).isEqualTo(1L);
+    }
+
+    @Test
+    void increaseWithBackUp() {
+        long articleId = 1L;
+        stringRedisTemplate.opsForValue().set(articleViewCountKey(articleId), "999");
+
+        Long result = articleViewService.increase(articleId, 1L);
+        ArticleViewCount articleViewCount = articleViewCountBackUpRepository.findById(articleId).get();
+
+        assertThat(result).isEqualTo(1000L);
+        assertThat(articleViewCount.getViewCount()).isEqualTo(1000L);
+    }
+
+    @DisplayName("articleId의 조회수를 캐시에서 읽어온다")
+    @Test
+    void count() {
+        long articleId = 1L;
+        stringRedisTemplate.opsForValue().set(articleViewCountKey(articleId), "777");
+
+        Long count = articleViewService.count(articleId);
+
+        assertThat(count).isEqualTo(777L);
+    }
+}

--- a/backend/view/src/test/resources/application-test.yml
+++ b/backend/view/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -75,3 +75,11 @@ create table article_like_count (
    article_id bigint not null primary key,
    like_count bigint not null
 );
+
+-- 게시글 조회수
+create database article_view;
+
+create table article_view_count (
+    article_id bigint not null primary key,
+    view_count bigint not null
+);


### PR DESCRIPTION
**Flow**
- redis에 게시글 조회수를 카운팅한다 
  - 이때 조회수 어뷰징을 위해 redis 분산락을 사용한다 (ttl = 10분) 
  - 락이 있는 사용자인 경우 게시글 조회수 읽어 반환
- 게시글 조회수가 `1000`(=BATCH_SIZE) 단위로 올라가면 DB에 백업한다 
- 이때 Redis 장애로 인해 정보 유실, 데이터 정합성 이슈에 대한 것은 고려하지 않음
![article_view_flow](https://github.com/user-attachments/assets/54e5f2b8-daaa-4156-b0ec-3d2f3926155c)

**참고. Redis 장애시 조회수 유실에 대한 전략**
-  Lazy 초기화 전략 : 조회수 조회/증가 시점에 Redis 캐시가 없으면 DB에서 초기화
- 서버 기동 시 일괄 초기화 (@EventListener) : Top N 게시글 대상
- Redis AOF/RDB 영속화


