### PR TITLE
Hot article (인기 게시글)

### DIFF
--- a/backend/article/build.gradle
+++ b/backend/article/build.gradle
@@ -5,4 +5,6 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation project(':backend:common:snowflake')
     implementation project(':backend:common:support')
+    implementation project(':backend:common:event')
+    implementation project(':backend:common:outbox-message-relay')
 }

--- a/backend/article/src/main/java/com/example/article/ArticleApplication.java
+++ b/backend/article/src/main/java/com/example/article/ArticleApplication.java
@@ -2,7 +2,11 @@ package com.example.article;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example")
 @SpringBootApplication
 public class ArticleApplication {
     public static void main(String[] args) {

--- a/backend/article/src/main/resources/application.yml
+++ b/backend/article/src/main/resources/application.yml
@@ -3,3 +3,20 @@ server:
 spring:
   application:
     name: article-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/article
+    username: tester
+    password: 1234
+  jpa:
+      database-platform: org.hibernate.dialect.MySQLDialect
+      open-in-view: false
+      show-sql: true
+      hibernate:
+        ddl-auto: none
+  data:
+      redis:
+        host: 127.0.0.1
+        port: 6379
+  kafka:
+      bootstrap-servers: 127.0.0.1:9092

--- a/backend/article/src/test/java/com/example/article/controller/ArticleControllerTest.java
+++ b/backend/article/src/test/java/com/example/article/controller/ArticleControllerTest.java
@@ -5,6 +5,7 @@ import com.example.article.repository.ArticleRepository;
 import com.example.article.service.request.ArticleCreateRequest;
 import com.example.article.service.request.ArticleUpdateRequest;
 import com.example.article.service.response.ArticleResponse;
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +44,9 @@ class ArticleControllerTest {
 
     @Autowired
     private ArticleRepository articleRepository;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     @BeforeEach
     void setUp() {

--- a/backend/article/src/test/resources/application-test.yml
+++ b/backend/article/src/test/resources/application-test.yml
@@ -3,6 +3,7 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -12,3 +13,5 @@ spring:
       hibernate:
         format_sql: false
     defer-datasource-initialization: true
+  autoconfigure:
+    exclude: com.example.outboxmessagerelay.MessageRelayConfig

--- a/backend/comment/build.gradle
+++ b/backend/comment/build.gradle
@@ -5,4 +5,6 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation project(':backend:common:snowflake')
     implementation project(':backend:common:support')
+    implementation project(':backend:common:event')
+    implementation project(':backend:common:outbox-message-relay')
 }

--- a/backend/comment/src/main/java/com/example/comment/CommentApplication.java
+++ b/backend/comment/src/main/java/com/example/comment/CommentApplication.java
@@ -2,7 +2,11 @@ package com.example.comment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example")
 @SpringBootApplication
 public class CommentApplication {
     public static void main(String[] args) {

--- a/backend/comment/src/main/java/com/example/comment/controller/CommentControllerV2.java
+++ b/backend/comment/src/main/java/com/example/comment/controller/CommentControllerV2.java
@@ -5,6 +5,7 @@ import com.example.comment.service.request.CommentCreateRequestV2;
 import com.example.comment.service.response.CommentPageResponseV2;
 import com.example.comment.service.response.CommentResponseV2;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 // 열겨형 path 활용한 무한 depth 방식
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class CommentControllerV2 {
@@ -25,6 +27,7 @@ public class CommentControllerV2 {
 
     @PostMapping("/v2/comment")
     public ResponseEntity<CommentResponseV2> create(@RequestBody CommentCreateRequestV2 request) {
+        log.info("CommentControllerV2 request = {}", request);
         CommentResponseV2 response = commentService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/backend/comment/src/main/resources/application.yml
+++ b/backend/comment/src/main/resources/application.yml
@@ -3,3 +3,20 @@ server:
 spring:
   application:
     name: article-comment-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/comment
+    username: tester
+    password: 1234
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+  kafka:
+    bootstrap-servers: 127.0.0.1:9092

--- a/backend/comment/src/test/java/com/example/comment/controller/CommentControllerTest.java
+++ b/backend/comment/src/test/java/com/example/comment/controller/CommentControllerTest.java
@@ -4,6 +4,7 @@ import com.example.comment.entity.Comment;
 import com.example.comment.repository.CommentRepository;
 import com.example.comment.service.request.CommentCreateRequest;
 import com.example.comment.service.response.CommentResponse;
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -43,6 +45,9 @@ class CommentControllerTest {
 
     @Autowired
     private CommentRepository commentRepository;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     @BeforeEach
     void setUp() {

--- a/backend/comment/src/test/java/com/example/comment/controller/CommentControllerV2Test.java
+++ b/backend/comment/src/test/java/com/example/comment/controller/CommentControllerV2Test.java
@@ -6,6 +6,7 @@ import com.example.comment.repository.CommentRepositoryV2;
 import com.example.comment.service.request.CommentCreateRequestV2;
 import com.example.comment.service.response.CommentPageResponseV2;
 import com.example.comment.service.response.CommentResponseV2;
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -46,6 +48,9 @@ class CommentControllerV2Test {
 
     @Autowired
     private CommentRepositoryV2 commentRepository;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     /*
        샘플 데이터 (1depth : 00000 ~ 00009, 2depth: 각 10개씩, 총 11 * 10 = 110개)

--- a/backend/comment/src/test/resources/application-test.yml
+++ b/backend/comment/src/test/resources/application-test.yml
@@ -3,6 +3,7 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -12,3 +13,5 @@ spring:
       hibernate:
         format_sql: false
     defer-datasource-initialization: true
+  autoconfigure:
+    exclude: com.example.outboxmessagerelay.MessageRelayConfig

--- a/backend/common/data-serializer/build.gradle
+++ b/backend/common/data-serializer/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+}

--- a/backend/common/data-serializer/src/main/java/com/example/dataserializer/DataSerializer.java
+++ b/backend/common/data-serializer/src/main/java/com/example/dataserializer/DataSerializer.java
@@ -11,13 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DataSerializer {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    private static ObjectMapper init() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     public static <T> T deserialize(String data, Class<T> clazz) {
         try {

--- a/backend/common/data-serializer/src/main/java/com/example/dataserializer/DataSerializer.java
+++ b/backend/common/data-serializer/src/main/java/com/example/dataserializer/DataSerializer.java
@@ -1,0 +1,43 @@
+package com.example.dataserializer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DataSerializer {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static ObjectMapper init() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public static <T> T deserialize(String data, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(data, clazz);
+        } catch (JsonProcessingException e) {
+            log.error("[DataSerializer.deserialize] data = {}, clazz = {}", data, clazz, e);
+            return null;
+        }
+    }
+
+    public static <T> T deserialize(Object data, Class<T> clazz) {
+        return objectMapper.convertValue(data, clazz);
+    }
+
+    public static String serialize(Object data) {
+        try {
+            return objectMapper.writeValueAsString(data);
+        } catch (JsonProcessingException e) {
+            log.error("[DataSerializer.serialize] data = {}", data, e);
+            return null;
+        }
+    }
+}

--- a/backend/common/event/build.gradle
+++ b/backend/common/event/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':backend:common:data-serializer')
+}

--- a/backend/common/event/src/main/java/com/example/event/Event.java
+++ b/backend/common/event/src/main/java/com/example/event/Event.java
@@ -1,0 +1,48 @@
+package com.example.event;
+
+import com.example.dataserializer.DataSerializer;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Event <T extends EventPayload> {
+    private Long eventId;
+    private EventType type;
+    private T payload;
+
+    public static Event<EventPayload> of(Long articleId, EventType type, EventPayload payload) {
+        Event<EventPayload> event = new Event<>();
+        event.eventId = articleId;
+        event.type = type;
+        event.payload = payload;
+        return event;
+    }
+
+    public String toJson() {
+        return DataSerializer.serialize(this);
+    }
+
+    public static Event<EventPayload> fromJson(String json) {
+        EventRaw eventRaw = DataSerializer.deserialize(json, EventRaw.class);
+        if(eventRaw == null) {
+            return null;
+        }
+
+        Event<EventPayload> event = new Event<>();
+        event.eventId = eventRaw.getEventId();
+        event.type = EventType.from(eventRaw.getType());
+        event.payload = DataSerializer.deserialize(eventRaw.getPayload(), Objects.requireNonNull(event.type).getPayloadClass());
+        return event;
+    }
+
+    @Getter
+    private static class EventRaw {
+        private Long eventId;
+        private String type;
+        private Object payload;
+    }
+}

--- a/backend/common/event/src/main/java/com/example/event/EventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/EventPayload.java
@@ -1,0 +1,4 @@
+package com.example.event;
+
+public interface EventPayload {
+}

--- a/backend/common/event/src/main/java/com/example/event/EventType.java
+++ b/backend/common/event/src/main/java/com/example/event/EventType.java
@@ -1,0 +1,46 @@
+package com.example.event;
+
+import com.example.event.paylod.ArticleCreatedEventPayload;
+import com.example.event.paylod.ArticleDeletedEventPayload;
+import com.example.event.paylod.ArticleLikedEventPayload;
+import com.example.event.paylod.ArticleUnlikedEventPayload;
+import com.example.event.paylod.ArticleUpdatedEventPayload;
+import com.example.event.paylod.ArticleViewedEventPayload;
+import com.example.event.paylod.CommentCreatedEventPayload;
+import com.example.event.paylod.CommentDeletedEventPayload;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+    ARTICLE_CREATED(ArticleCreatedEventPayload.class, Topic.BOARD_ARTICLE),
+    ARTICLE_UPDATED(ArticleUpdatedEventPayload.class, Topic.BOARD_ARTICLE),
+    ARTICLE_DELETED(ArticleDeletedEventPayload.class, Topic.BOARD_ARTICLE),
+    COMMENT_CREATED(CommentCreatedEventPayload.class, Topic.BOARD_COMMENT),
+    COMMENT_DELETED(CommentDeletedEventPayload.class, Topic.BOARD_COMMENT),
+    ARTICLE_LIKED(ArticleLikedEventPayload.class, Topic.BOARD_LIKE),
+    ARTICLE_UNLIKED(ArticleUnlikedEventPayload.class, Topic.BOARD_LIKE),
+    ARTICLE_VIEWED(ArticleViewedEventPayload.class, Topic.BOARD_VIEW);
+
+    private final Class<? extends EventPayload> payloadClass;
+    private final String topic;
+
+    public static EventType from(String type) {
+        try {
+            return valueOf(type);
+        } catch (Exception e) {
+            log.error("[EventType.from] type = {}", type, e);
+            return null;
+        }
+    }
+
+    public static class Topic {
+        public static final String BOARD_ARTICLE = "board-article";
+        public static final String BOARD_COMMENT = "board-comment";
+        public static final String BOARD_LIKE = "board-like";
+        public static final String BOARD_VIEW = "board-view";
+    }
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleCreatedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleCreatedEventPayload.java
@@ -1,0 +1,24 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleCreatedEventPayload implements EventPayload {
+    private Long articleId;
+    private String title;
+    private String content;
+    private Long boardId;
+    private Long writerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Long boardArticleCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleDeletedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleDeletedEventPayload.java
@@ -1,0 +1,24 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleDeletedEventPayload implements EventPayload {
+    private Long articleId;
+    private String title;
+    private String content;
+    private Long boardId;
+    private Long writerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Long boardArticleCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleLikedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleLikedEventPayload.java
@@ -1,0 +1,21 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleLikedEventPayload implements EventPayload {
+    private Long articleLikeId;
+    private Long articleId;
+    private Long userId;
+    private LocalDateTime createdAt;
+    private Long articleLikeCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleUnlikedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleUnlikedEventPayload.java
@@ -1,0 +1,21 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleUnlikedEventPayload implements EventPayload {
+    private Long articleLikeId;
+    private Long articleId;
+    private Long userId;
+    private LocalDateTime createdAt;
+    private Long articleLikeCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleUpdatedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleUpdatedEventPayload.java
@@ -1,0 +1,23 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleUpdatedEventPayload implements EventPayload {
+    private Long articleId;
+    private String title;
+    private String content;
+    private Long boardId;
+    private Long writerId;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/ArticleViewedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/ArticleViewedEventPayload.java
@@ -1,0 +1,16 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleViewedEventPayload implements EventPayload {
+    private Long articleId;
+    private Long articleViewCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/CommentCreatedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/CommentCreatedEventPayload.java
@@ -1,0 +1,24 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreatedEventPayload implements EventPayload {
+    private Long commentId;
+    private String content;
+    private String path;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+    private Long articleCommentCount;
+}

--- a/backend/common/event/src/main/java/com/example/event/paylod/CommentDeletedEventPayload.java
+++ b/backend/common/event/src/main/java/com/example/event/paylod/CommentDeletedEventPayload.java
@@ -1,0 +1,24 @@
+package com.example.event.paylod;
+
+import com.example.event.EventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDeletedEventPayload implements EventPayload {
+    private Long commentId;
+    private String content;
+    private String path;
+    private Long articleId;
+    private Long writerId;
+    private Boolean deleted;
+    private LocalDateTime createdAt;
+    private Long articleCommentCount;
+}

--- a/backend/common/event/src/test/java/com/example/event/EventTypeTest.java
+++ b/backend/common/event/src/test/java/com/example/event/EventTypeTest.java
@@ -1,0 +1,34 @@
+package com.example.event;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventTypeTest {
+
+    @ParameterizedTest
+    @MethodSource("provideEventType")
+    void from(String type, EventType expected) {
+        EventType eventType = EventType.from(type);
+
+        assertThat(eventType).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideEventType() {
+        return Stream.of(
+                Arguments.of("ARTICLE_CREATED", EventType.ARTICLE_CREATED),
+                Arguments.of("ARTICLE_UPDATED", EventType.ARTICLE_UPDATED),
+                Arguments.of("ARTICLE_DELETED", EventType.ARTICLE_DELETED),
+                Arguments.of("COMMENT_CREATED", EventType.COMMENT_CREATED),
+                Arguments.of("COMMENT_DELETED", EventType.COMMENT_DELETED),
+                Arguments.of("ARTICLE_LIKED", EventType.ARTICLE_LIKED),
+                Arguments.of("ARTICLE_UNLIKED", EventType.ARTICLE_UNLIKED),
+                Arguments.of("ARTICLE_VIEWED", EventType.ARTICLE_VIEWED)
+        );
+    }
+
+}

--- a/backend/common/outbox-message-relay/build.gradle
+++ b/backend/common/outbox-message-relay/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.kafka:spring-kafka'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation project(':backend:common:snowflake')
+    implementation project(':backend:common:event')
+    implementation project(':backend:common:data-serializer')
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/AssignedShard.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/AssignedShard.java
@@ -1,0 +1,43 @@
+package com.example.outboxmessagerelay;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AssignedShard {
+    private List<Long> shards;
+
+    public static AssignedShard of(String appId, List<String> appIds, long shardCount) {
+        AssignedShard assignedShard = new AssignedShard();
+        assignedShard.shards = assign(appId, appIds, shardCount);
+        return assignedShard;
+    }
+
+    private static List<Long> assign(String appId, List<String> appIds, long shardCount) {
+        int appIdx = findAppIndex(appId, appIds);
+        if(appIdx == -1) {
+            return Collections.emptyList();
+        }
+
+        long start = appIdx * shardCount / appIds.size();
+        long end = (appIdx + 1) * shardCount / appIds.size() - 1;
+
+        return LongStream.rangeClosed(start, end).boxed().toList();
+    }
+
+    private static int findAppIndex(String appId, List<String> appIds) {
+        for(int i = 0; i < appIds.size(); i++) {
+            if(appIds.get(i).equals(appId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelay.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelay.java
@@ -1,0 +1,70 @@
+package com.example.outboxmessagerelay;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageRelay {
+    private final OutboxRepository outboxRepository;
+    private final MessageRelayCoordinator messageRelayCoordinator;
+    private final KafkaTemplate<String, String> messageRelayTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(OutboxEvent outboxEvent) {
+        log.info("[MessageRelay.saveOutbox] outboxEvent: {}", outboxEvent);
+        outboxRepository.save(outboxEvent.getOutbox());
+    }
+
+    @Async("messageRelayPublishEventExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(OutboxEvent outboxEvent) {
+        publishEvent(outboxEvent.getOutbox());
+    }
+
+    private void publishEvent(Outbox outbox) {
+        try {
+            messageRelayTemplate.send(
+                    outbox.getEventType().getTopic(),
+                    String.valueOf(outbox.getShardKey()),
+                    outbox.getPayload()
+            ).get(1, TimeUnit.SECONDS);
+            outboxRepository.delete(outbox);
+        } catch (Exception e) {
+            log.error("[MessageRelay.publishEvent] outbox = {}", outbox, e);
+        }
+    }
+
+    @Scheduled(
+            fixedDelay = 10,
+            initialDelay = 5,
+            timeUnit = TimeUnit.SECONDS,
+            scheduler = "messageRelayPublishPendingEventExecutor"
+    )
+    public void publishPendingEvent() {
+        AssignedShard assignedShard = messageRelayCoordinator.assignShards();
+        List<Long> shards = assignedShard.getShards();
+        log.info("[MessageRelay.publishPendingEvent] assignedShard size = {}", shards.size());
+
+        shards.forEach(this::rePublishEvent);
+    }
+
+    private void rePublishEvent(Long shard) {
+        List<Outbox> outboxes = outboxRepository.findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
+                shard, LocalDateTime.now().minusSeconds(10), Pageable.ofSize(100));
+
+        outboxes.forEach(this::publishEvent);
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayConfig.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayConfig.java
@@ -1,0 +1,55 @@
+package com.example.outboxmessagerelay;
+
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@EnableAsync
+@EnableScheduling
+@Configuration
+@ComponentScan("com.example.outboxmessagerelay")
+public class MessageRelayConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaTemplate<String, String> messageRelayKafkaTemplate() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(configProps));
+    }
+
+    @Bean
+    public Executor messageRelayPublishEventExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("message-relay-pub-event-");
+        return executor;
+    }
+
+    @Bean
+    public ScheduledExecutorService messageRelayPublishPendingEventExecutor() {
+        return Executors.newSingleThreadScheduledExecutor();
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayConstants.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayConstants.java
@@ -1,0 +1,9 @@
+package com.example.outboxmessagerelay;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MessageRelayConstants {
+    public static final int SHARD_COUNT = 4; // 임의 값
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayCoordinator.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/MessageRelayCoordinator.java
@@ -1,0 +1,64 @@
+package com.example.outboxmessagerelay;
+
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class MessageRelayCoordinator {
+    private static final int PING_INTERVAL_SECONDS = 3;
+    private static final int PING_FAILURE_THRESHOLD = 3;
+    private static final String APP_ID = UUID.randomUUID().toString();
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${spring.application.name}")
+    private String applicationName;
+
+    public AssignedShard assignShards() {
+        return AssignedShard.of(APP_ID, findAppIds(), MessageRelayConstants.SHARD_COUNT);
+    }
+
+    private List<String> findAppIds() {
+        return redisTemplate.opsForZSet().reverseRange(generateKey(), 0, -1)
+                .stream()
+                .sorted()
+                .toList();
+    }
+
+    private String generateKey() {
+        return "message-relay-coordinator::app-list::%s".formatted(applicationName);
+    }
+
+    @PreDestroy
+    public void leave() {
+        redisTemplate.opsForZSet().remove(generateKey(), APP_ID);
+    }
+
+    @Scheduled(fixedDelay = PING_INTERVAL_SECONDS, timeUnit = TimeUnit.SECONDS)
+    public void ping() {
+        redisTemplate.executePipelined((RedisCallback<?>) action -> {
+            StringRedisConnection connection = (StringRedisConnection) action;
+            String key = generateKey();
+            connection.zAdd(key, Instant.now().toEpochMilli(), APP_ID);
+            connection.zRemRangeByScore(
+                key,
+                Double.NEGATIVE_INFINITY,
+                Instant.now().minusSeconds(PING_INTERVAL_SECONDS * PING_FAILURE_THRESHOLD).toEpochMilli()
+            );
+
+            return null;
+        });
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/Outbox.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/Outbox.java
@@ -1,0 +1,43 @@
+package com.example.outboxmessagerelay;
+
+import com.example.event.EventType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Table(name = "outbox")
+@Getter
+@Entity
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Outbox {
+    @Id
+    private Long outboxId;
+
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+
+    private String payload;
+
+    private Long shardKey;
+
+    private LocalDateTime createdAt;
+
+    public static Outbox of(Long outboxId, EventType eventType, String payload, Long shardKey) {
+        Outbox outbox = new Outbox();
+        outbox.outboxId = outboxId;
+        outbox.eventType = eventType;
+        outbox.payload = payload;
+        outbox.shardKey = shardKey;
+        outbox.createdAt = LocalDateTime.now();
+        return outbox;
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxEvent.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxEvent.java
@@ -1,0 +1,16 @@
+package com.example.outboxmessagerelay;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class OutboxEvent {
+    private Outbox outbox;
+
+    public static OutboxEvent from(Outbox outbox) {
+        OutboxEvent outboxEvent = new OutboxEvent();
+        outboxEvent.outbox = outbox;
+        return outboxEvent;
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxEventPublisher.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxEventPublisher.java
@@ -1,0 +1,28 @@
+package com.example.outboxmessagerelay;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.snowflake.Snowflake;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPublisher {
+    private final Snowflake outboxIdSnowflake = new Snowflake();
+    private final Snowflake eventIdSnowflake = new Snowflake();
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publish(EventType type, EventPayload payload, Long shardKey) {
+        Outbox outbox = Outbox.of(
+                outboxIdSnowflake.nextId(),
+                type,
+                Event.of(eventIdSnowflake.nextId(), type, payload).toJson(),
+                shardKey % MessageRelayConstants.SHARD_COUNT
+        );
+
+        eventPublisher.publishEvent(OutboxEvent.from(outbox));
+    }
+}

--- a/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxRepository.java
+++ b/backend/common/outbox-message-relay/src/main/java/com/example/outboxmessagerelay/OutboxRepository.java
@@ -1,0 +1,18 @@
+package com.example.outboxmessagerelay;
+
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface OutboxRepository extends JpaRepository<Outbox, Long> {
+    List<Outbox> findAllByShardKeyAndCreatedAtLessThanEqualOrderByCreatedAtAsc(
+            Long shardKey,
+            LocalDateTime createdAt,
+            Pageable pageable
+    );
+}

--- a/backend/common/outbox-message-relay/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/backend/common/outbox-message-relay/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.example.outboxmessagerelay.MessageRelayConfig

--- a/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/AssignedShardTest.java
+++ b/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/AssignedShardTest.java
@@ -1,0 +1,26 @@
+package com.example.outboxmessagerelay;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssignedShardTest {
+
+    @Test
+    void shards() {
+        long shardCount = 10L;
+        List<String> apps = List.of("appId1", "appId2", "appId3");
+
+        AssignedShard assignedShard1 = AssignedShard.of("appId1", apps, shardCount);
+        AssignedShard assignedShard2 = AssignedShard.of("appId2", apps, shardCount);
+        AssignedShard assignedShard3 = AssignedShard.of("appId3", apps, shardCount);
+        AssignedShard assignedShard4 = AssignedShard.of("invalid", apps, shardCount);
+
+        assertThat(assignedShard1.getShards()).containsExactly(0L, 1L, 2L);
+        assertThat(assignedShard2.getShards()).containsExactly(3L, 4L, 5L);
+        assertThat(assignedShard3.getShards()).containsExactly(6L, 7L, 8L, 9L);
+        assertThat(assignedShard4.getShards()).isEmpty();
+    }
+}

--- a/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/MessageRelayTest.java
+++ b/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/MessageRelayTest.java
@@ -1,0 +1,17 @@
+package com.example.outboxmessagerelay;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = TestApplication.class)
+public class MessageRelayTest {
+
+    @DisplayName("")
+    @Test
+    void test() {
+        System.out.println("확인");
+    }
+}

--- a/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/TestApplication.java
+++ b/backend/common/outbox-message-relay/src/test/java/com/example/outboxmessagerelay/TestApplication.java
@@ -1,0 +1,7 @@
+package com.example.outboxmessagerelay;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackageClasses = MessageRelayConfig.class)
+public class TestApplication {
+}

--- a/backend/hot-article/build.gradle
+++ b/backend/hot-article/build.gradle
@@ -1,3 +1,9 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    testImplementation 'com.github.codemonstur:embedded-redis:1.0.0'
+
+    implementation project(':backend:common:event')
 }

--- a/backend/hot-article/build.gradle
+++ b/backend/hot-article/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
 
     testImplementation 'com.github.codemonstur:embedded-redis:1.0.0'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     implementation project(':backend:common:event')
 }

--- a/backend/hot-article/src/main/java/com/example/hotarticle/client/ArticleClient.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/client/ArticleClient.java
@@ -1,6 +1,6 @@
 package com.example.hotarticle.client;
 
-import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,19 +12,14 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class ArticleClient {
-    private RestClient restClient;
+    private final RestClient restClient;
 
-    @Value("${endpoints.board-article-service.url}")
-    private String articleServiceUrl;
-
-    @PostConstruct
-    void init() {
-        this.restClient = RestClient.create(articleServiceUrl);
+    public ArticleClient(RestClient.Builder builder, @Value("${endpoints.board-article-service.url}") String articleServiceUrl) {
+        this.restClient = builder.baseUrl(articleServiceUrl).build();
     }
 
-    public ArticleResponse of(Long articleId) {
+    public ArticleResponse read(Long articleId) {
         try {
             return restClient.get()
                     .uri("/v1/article/{articleId}", articleId)
@@ -37,6 +32,7 @@ public class ArticleClient {
     }
 
     @Getter
+    @AllArgsConstructor
     public static class ArticleResponse {
         private Long articleId;
         private String title;

--- a/backend/hot-article/src/main/java/com/example/hotarticle/client/ArticleClient.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/client/ArticleClient.java
@@ -1,0 +1,45 @@
+package com.example.hotarticle.client;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArticleClient {
+    private RestClient restClient;
+
+    @Value("${endpoints.board-article-service.url}")
+    private String articleServiceUrl;
+
+    @PostConstruct
+    void init() {
+        this.restClient = RestClient.create(articleServiceUrl);
+    }
+
+    public ArticleResponse of(Long articleId) {
+        try {
+            return restClient.get()
+                    .uri("/v1/article/{articleId}", articleId)
+                    .retrieve()
+                    .body(ArticleResponse.class);
+        } catch (Exception e) {
+            log.error("[ArticleClient.read] articleId = {}", articleId, e);
+            return null;
+        }
+    }
+
+    @Getter
+    public static class ArticleResponse {
+        private Long articleId;
+        private String title;
+        private LocalDateTime createdAt;
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/config/KafkaConfig.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/config/KafkaConfig.java
@@ -1,0 +1,19 @@
+package com.example.hotarticle.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(ConsumerFactory<String, String> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/config/KafkaConfig.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/config/KafkaConfig.java
@@ -2,10 +2,12 @@ package com.example.hotarticle.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
 
+@EnableKafka
 @Configuration
 public class KafkaConfig {
 

--- a/backend/hot-article/src/main/java/com/example/hotarticle/consumer/HotArticleEventConsumer.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/consumer/HotArticleEventConsumer.java
@@ -1,0 +1,34 @@
+package com.example.hotarticle.consumer;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.hotarticle.service.HotArticleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotArticleEventConsumer {
+    private final HotArticleService hotArticleService;
+
+    @KafkaListener(topics = {
+            EventType.Topic.BOARD_ARTICLE,
+            EventType.Topic.BOARD_COMMENT,
+            EventType.Topic.BOARD_LIKE,
+            EventType.Topic.BOARD_VIEW,
+    })
+    public void listener(String message, Acknowledgment ack) {
+        log.info("[HotArticleEventConsumer.listener] received message={}", message);
+        Event<EventPayload> event = Event.fromJson(message);
+        if(event != null) {
+            hotArticleService.handleEvent(event);
+        }
+
+        ack.acknowledge();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/controller/HotArticleController.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/controller/HotArticleController.java
@@ -1,0 +1,24 @@
+package com.example.hotarticle.controller;
+
+import com.example.hotarticle.service.HotArticleService;
+import com.example.hotarticle.service.response.HotArticleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class HotArticleController {
+    private final HotArticleService hotArticleService;
+
+    @GetMapping("/v1/hot-articles/articles/date/{dateStr}")
+    public ResponseEntity<List<HotArticleResponse>> readAll(
+            @PathVariable("dateStr") String dateStr
+    ) {
+        return ResponseEntity.ok(hotArticleService.readAll(dateStr));
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/controller/HotArticleController.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/controller/HotArticleController.java
@@ -3,6 +3,7 @@ package com.example.hotarticle.controller;
 import com.example.hotarticle.service.HotArticleService;
 import com.example.hotarticle.service.response.HotArticleResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class HotArticleController {
@@ -19,6 +21,7 @@ public class HotArticleController {
     public ResponseEntity<List<HotArticleResponse>> readAll(
             @PathVariable("dateStr") String dateStr
     ) {
+        log.info("[HotArticleController.readAll] dateStr: {}", dateStr);
         return ResponseEntity.ok(hotArticleService.readAll(dateStr));
     }
 }

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleCommentCountRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleCommentCountRepository.java
@@ -1,0 +1,29 @@
+package com.example.hotarticle.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleCommentCountRepository {
+    // hot-article::article::{articleId}::comment-count
+    private static final String KEY_FORMAT = "hot-article::article::%s::comment-count";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Long read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return (result == null) ? 0L : Long.parseLong(result);
+    }
+
+    public void createOrUpdate(Long articleId, Long commentCount, Duration ttl) {
+        redisTemplate.opsForValue().set(generateKey(articleId), String.valueOf(commentCount), ttl);
+    }
+
+    private String generateKey(Long articleId) {
+        return KEY_FORMAT.formatted(articleId);
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleCreatedTimeRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleCreatedTimeRepository.java
@@ -1,0 +1,40 @@
+package com.example.hotarticle.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleCreatedTimeRepository {
+    // hot-article::article::{articleId}::created-time
+    private static final String KEY_FORMAT = "hot-article::article::%s::created-time";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public LocalDateTime read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return (result == null)
+                ? null
+                : LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(result)), ZoneOffset.UTC);
+    }
+
+    public void createOrUpdate(Long articleId, LocalDateTime createdAt, Duration ttl) {
+        redisTemplate.opsForValue().set(generateKey(articleId),
+                String.valueOf(createdAt.toInstant(ZoneOffset.UTC).toEpochMilli()),
+                ttl);
+    }
+
+    public void delete(Long articleId) {
+        redisTemplate.delete(generateKey(articleId));
+    }
+
+    private String generateKey(Long articleId) {
+        return KEY_FORMAT.formatted(articleId);
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleLikeCountRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleLikeCountRepository.java
@@ -1,0 +1,29 @@
+package com.example.hotarticle.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleLikeCountRepository {
+    // hot-article::article::{articleId}::like-count
+    private static final String KEY_FORMAT = "hot-article::article::%s::like-count";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Long read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return (result == null) ? 0L : Long.parseLong(result);
+    }
+
+    public void createOrUpdate(Long articleId, Long likeCount, Duration ttl) {
+       redisTemplate.opsForValue().set(generateKey(articleId), String.valueOf(likeCount), ttl);
+    }
+
+    private String generateKey(Long articleId) {
+        return KEY_FORMAT.formatted(articleId);
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleViewCountRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/ArticleViewCountRepository.java
@@ -1,0 +1,29 @@
+package com.example.hotarticle.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleViewCountRepository {
+    // hot-article::article::{articleId}::view-count
+    private static final String KEY_FORMAT = "hot-article::article::{articleId}::view-count";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Long read(Long articleId) {
+        String result = redisTemplate.opsForValue().get(generateKey(articleId));
+        return (result == null) ? 0L : Long.parseLong(result);
+    }
+
+    public void createOrUpdate(Long articleId, Long viewCount, Duration ttl) {
+        redisTemplate.opsForValue().set(generateKey(articleId), String.valueOf(viewCount), ttl);
+    }
+
+    private String generateKey(Long articleId) {
+        return KEY_FORMAT.formatted(articleId);
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
@@ -42,9 +42,20 @@ public class HotArticleListRepository {
         return KEY_FORMAT.formatted(dateStr);
     }
 
+    // TODO. 제거
     public List<Long> readAll(LocalDateTime dateTime) {
         return redisTemplate.opsForZSet()
                 .reverseRange(generateKey(dateTime), 0, -1)
+                .stream()
+                .peek(v -> log.info("[HotArticleListRepository.readAll] articleId = {}", v))
+                .map(Long::valueOf)
+                .toList();
+    }
+
+    // TODO 전환
+    public List<Long> readAll(String dateStr) {
+        return redisTemplate.opsForZSet()
+                .reverseRange(generateKey(dateStr), 0, -1)
                 .stream()
                 .peek(v -> log.info("[HotArticleListRepository.readAll] articleId = {}", v))
                 .map(Long::valueOf)

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
@@ -42,17 +42,6 @@ public class HotArticleListRepository {
         return KEY_FORMAT.formatted(dateStr);
     }
 
-    // TODO. 제거
-    public List<Long> readAll(LocalDateTime dateTime) {
-        return redisTemplate.opsForZSet()
-                .reverseRange(generateKey(dateTime), 0, -1)
-                .stream()
-                .peek(v -> log.info("[HotArticleListRepository.readAll] articleId = {}", v))
-                .map(Long::valueOf)
-                .toList();
-    }
-
-    // TODO 전환
     public List<Long> readAll(String dateStr) {
         return redisTemplate.opsForZSet()
                 .reverseRange(generateKey(dateStr), 0, -1)

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
@@ -1,0 +1,53 @@
+package com.example.hotarticle.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class HotArticleListRepository {
+    // hot-article::list::{yyyyMMdd}
+    private static final String KEY_FORMAT = "hot-article::list::%s";
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void add(Long articleId, LocalDateTime dateTime, Long score, Long limit, Duration ttl) {
+        redisTemplate.executePipelined((RedisCallback<?>)  action -> {
+            StringRedisConnection connection = (StringRedisConnection) action;
+            String key = generateKey(dateTime);
+            connection.zAdd(key, score, String.valueOf(articleId));
+            connection.zRemRange(key, 0, - limit - 1);
+            connection.expire(key, ttl.toSeconds());
+            return null;
+        });
+    }
+
+    private String generateKey(LocalDateTime dateTime) {
+        return generateKey(TIME_FORMATTER.format(dateTime));
+    }
+
+    private String generateKey(String dateStr) {
+        return KEY_FORMAT.formatted(dateStr);
+    }
+
+    public List<Long> readAll(LocalDateTime dateTime) {
+        return redisTemplate.opsForZSet()
+                .reverseRange(generateKey(dateTime), 0, -1)
+                .stream()
+                .peek(v -> log.info("[HotArticleListRepository.readAll] articleId = {}", v))
+                .map(Long::valueOf)
+                .toList();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/repository/HotArticleListRepository.java
@@ -50,4 +50,8 @@ public class HotArticleListRepository {
                 .map(Long::valueOf)
                 .toList();
     }
+
+    public void remove(Long articleId, LocalDateTime dateTime) {
+        redisTemplate.opsForZSet().remove(generateKey(dateTime), String.valueOf(articleId));
+    }
 }

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleScoreCalculator.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleScoreCalculator.java
@@ -1,0 +1,29 @@
+package com.example.hotarticle.service;
+
+import com.example.hotarticle.repository.ArticleCommentCountRepository;
+import com.example.hotarticle.repository.ArticleLikeCountRepository;
+import com.example.hotarticle.repository.ArticleViewCountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HotArticleScoreCalculator {
+    private static final long ARTICLE_LIKE_COUNT_WEIGHT = 3;
+    private static final long ARTICLE_COMMENT_COUNT_WEIGHT = 2;
+    private static final long ARTICLE_VIEW_COUNT_WEIGHT = 1;
+
+    private final ArticleLikeCountRepository articleLikeCountRepository;
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+    private final ArticleViewCountRepository articleViewCountRepository;
+
+    public long calculate(Long articleId) {
+        Long likeCount = articleLikeCountRepository.read(articleId);
+        Long commentCount = articleCommentCountRepository.read(articleId);
+        Long viewCount = articleViewCountRepository.read(articleId);
+
+        return likeCount * ARTICLE_LIKE_COUNT_WEIGHT
+                + commentCount * ARTICLE_COMMENT_COUNT_WEIGHT
+                + viewCount * ARTICLE_VIEW_COUNT_WEIGHT;
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleScoreUpdater.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleScoreUpdater.java
@@ -1,0 +1,48 @@
+package com.example.hotarticle.service;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.hotarticle.repository.ArticleCreatedTimeRepository;
+import com.example.hotarticle.repository.HotArticleListRepository;
+import com.example.hotarticle.service.eventhandler.EventHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class HotArticleScoreUpdater {
+    private static final long HOT_ARTICLE_LIMIT = 10;
+    private static final Duration HOT_ARTICLE_TTL = Duration.ofDays(10);
+
+    private final ArticleCreatedTimeRepository articleCreatedTimeRepository;
+    private final HotArticleScoreCalculator hotArticleScoreCalculator;
+    private final HotArticleListRepository hotArticleListRepository;
+
+    public void update(Event<EventPayload> event, EventHandler<EventPayload> eventHandler) {
+        Long articleId = eventHandler.findArticleId(event);
+        LocalDateTime createdTime = articleCreatedTimeRepository.read(articleId);
+
+        if(isNotCreatedToday(createdTime)) {
+            return;
+        }
+
+        eventHandler.handle(event);
+
+        long score = hotArticleScoreCalculator.calculate(articleId);
+        hotArticleListRepository.add(
+                articleId,
+                createdTime,
+                score,
+                HOT_ARTICLE_LIMIT,
+                HOT_ARTICLE_TTL
+        );
+    }
+
+    private boolean isNotCreatedToday(LocalDateTime createdTime) {
+        return createdTime == null || !createdTime.toLocalDate().equals(LocalDate.now());
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleService.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleService.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class HotArticleService {
     private final ArticleClient articleClient;
-    private final List<EventHandler<EventPayload>> eventHandlers;
+    private final List<EventHandler> eventHandlers;
     private final HotArticleScoreUpdater hotArticleScoreUpdater;
     private final HotArticleListRepository hotArticleListRepository;
 

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleService.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/HotArticleService.java
@@ -1,0 +1,59 @@
+package com.example.hotarticle.service;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.hotarticle.client.ArticleClient;
+import com.example.hotarticle.repository.HotArticleListRepository;
+import com.example.hotarticle.service.eventhandler.EventHandler;
+import com.example.hotarticle.service.response.HotArticleResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HotArticleService {
+    private final ArticleClient articleClient;
+    private final List<EventHandler<EventPayload>> eventHandlers;
+    private final HotArticleScoreUpdater hotArticleScoreUpdater;
+    private final HotArticleListRepository hotArticleListRepository;
+
+    public void handleEvent(Event<EventPayload> event) {
+        EventHandler<EventPayload> eventHandler = findEventHandler(event);
+
+        if(eventHandler == null) {
+            return;
+        }
+
+        if(isArticleCreatedOrDeleted(event)) {
+            eventHandler.handle(event);
+        } else {
+            hotArticleScoreUpdater.update(event, eventHandler);
+        }
+    }
+
+    private EventHandler<EventPayload> findEventHandler(Event<EventPayload> event) {
+        return eventHandlers.stream()
+                .filter(eventHandler -> eventHandler.support(event))
+                .findAny()
+                .orElse(null);
+    }
+
+    private boolean isArticleCreatedOrDeleted(Event<EventPayload> event) {
+        return (EventType.ARTICLE_CREATED == event.getType() || EventType.ARTICLE_DELETED == event.getType());
+    }
+
+    public List<HotArticleResponse> readAll(String dateStr) {
+        return hotArticleListRepository.readAll(dateStr)
+                .stream()
+                .map(articleClient::read)
+                .filter(Objects::nonNull)
+                .map(HotArticleResponse::from)
+                .toList();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleCreatedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleCreatedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleCreatedEventPayload;
+import com.example.hotarticle.repository.ArticleCreatedTimeRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleCreatedEventHandler implements EventHandler<ArticleCreatedEventPayload> {
+    private final ArticleCreatedTimeRepository articleCreatedTimeRepository;
+
+    @Override
+    public Long findArticleId(Event<ArticleCreatedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<ArticleCreatedEventPayload> event) {
+        ArticleCreatedEventPayload payload = event.getPayload();
+        articleCreatedTimeRepository.createOrUpdate(
+                payload.getArticleId(),
+                payload.getCreatedAt(),
+                TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<ArticleCreatedEventPayload> event) {
+        return EventType.ARTICLE_CREATED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleDeletedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleDeletedEventHandler.java
@@ -1,0 +1,33 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleDeletedEventPayload;
+import com.example.hotarticle.repository.ArticleCreatedTimeRepository;
+import com.example.hotarticle.repository.HotArticleListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleDeletedEventHandler implements EventHandler<ArticleDeletedEventPayload> {
+    private final HotArticleListRepository hotArticleListRepository;
+    private final ArticleCreatedTimeRepository articleCreatedTimeRepository;
+
+    @Override
+    public Long findArticleId(Event<ArticleDeletedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<ArticleDeletedEventPayload> event) {
+        ArticleDeletedEventPayload payload = event.getPayload();
+        articleCreatedTimeRepository.delete(payload.getArticleId());
+        hotArticleListRepository.remove(payload.getArticleId(), payload.getCreatedAt());
+    }
+
+    @Override
+    public boolean support(Event<ArticleDeletedEventPayload> event) {
+        return EventType.ARTICLE_DELETED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleLikedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleLikedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleLikedEventPayload;
+import com.example.hotarticle.repository.ArticleLikeCountRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleLikedEventHandler implements EventHandler<ArticleLikedEventPayload>{
+    private final ArticleLikeCountRepository articleLikeCountRepository;
+
+    @Override
+    public Long findArticleId(Event<ArticleLikedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<ArticleLikedEventPayload> event) {
+        ArticleLikedEventPayload payload = event.getPayload();
+        articleLikeCountRepository.createOrUpdate(
+                payload.getArticleId(),
+                payload.getArticleLikeCount(),
+                TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<ArticleLikedEventPayload> event) {
+        return EventType.ARTICLE_LIKED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleUnlikedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleUnlikedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleUnlikedEventPayload;
+import com.example.hotarticle.repository.ArticleLikeCountRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleUnlikedEventHandler implements EventHandler<ArticleUnlikedEventPayload> {
+    private final ArticleLikeCountRepository articleLikeCountRepository;
+
+    @Override
+    public Long findArticleId(Event<ArticleUnlikedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<ArticleUnlikedEventPayload> event) {
+        ArticleUnlikedEventPayload payload = event.getPayload();
+        articleLikeCountRepository.createOrUpdate(
+                payload.getArticleId(),
+                payload.getArticleLikeCount(),
+                TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<ArticleUnlikedEventPayload> event) {
+        return EventType.ARTICLE_UNLIKED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleViewedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/ArticleViewedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleViewedEventPayload;
+import com.example.hotarticle.repository.ArticleViewCountRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ArticleViewedEventHandler implements EventHandler<ArticleViewedEventPayload> {
+    private final ArticleViewCountRepository articleViewCountRepository;
+
+    @Override
+    public Long findArticleId(Event<ArticleViewedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<ArticleViewedEventPayload> event) {
+        ArticleViewedEventPayload payload = event.getPayload();
+        articleViewCountRepository.createOrUpdate(
+            payload.getArticleId(),
+            payload.getArticleViewCount(),
+            TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<ArticleViewedEventPayload> event) {
+        return EventType.ARTICLE_VIEWED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/CommentCreatedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/CommentCreatedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.CommentCreatedEventPayload;
+import com.example.hotarticle.repository.ArticleCommentCountRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CommentCreatedEventHandler implements EventHandler<CommentCreatedEventPayload>{
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+
+    @Override
+    public Long findArticleId(Event<CommentCreatedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<CommentCreatedEventPayload> event) {
+        CommentCreatedEventPayload payload = event.getPayload();
+        articleCommentCountRepository.createOrUpdate(
+                payload.getArticleId(),
+                payload.getArticleCommentCount(),
+                TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<CommentCreatedEventPayload> event) {
+        return EventType.COMMENT_CREATED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/CommentDeletedEventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/CommentDeletedEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventType;
+import com.example.event.paylod.CommentDeletedEventPayload;
+import com.example.hotarticle.repository.ArticleCommentCountRepository;
+import com.example.hotarticle.utils.TimeCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CommentDeletedEventHandler implements EventHandler<CommentDeletedEventPayload>{
+    private final ArticleCommentCountRepository articleCommentCountRepository;
+
+    @Override
+    public Long findArticleId(Event<CommentDeletedEventPayload> event) {
+        return event.getPayload().getArticleId();
+    }
+
+    @Override
+    public void handle(Event<CommentDeletedEventPayload> event) {
+        CommentDeletedEventPayload payload = event.getPayload();
+        articleCommentCountRepository.createOrUpdate(
+                payload.getArticleId(),
+                payload.getArticleCommentCount(),
+                TimeCalculator.calculateDurationToMidnight(LocalDateTime.now())
+        );
+    }
+
+    @Override
+    public boolean support(Event<CommentDeletedEventPayload> event) {
+        return EventType.COMMENT_DELETED == event.getType();
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/EventHandler.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/eventhandler/EventHandler.java
@@ -1,0 +1,10 @@
+package com.example.hotarticle.service.eventhandler;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+
+public interface EventHandler<T extends EventPayload> {
+    Long findArticleId(Event<T> event);
+    void handle(Event<T> event);
+    boolean support(Event<T> event);
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/response/HotArticleResponse.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/response/HotArticleResponse.java
@@ -4,9 +4,11 @@ import com.example.hotarticle.client.ArticleClient;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
+@ToString
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/backend/hot-article/src/main/java/com/example/hotarticle/service/response/HotArticleResponse.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/service/response/HotArticleResponse.java
@@ -1,0 +1,25 @@
+package com.example.hotarticle.service.response;
+
+import com.example.hotarticle.client.ArticleClient;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HotArticleResponse {
+    private Long articleId;
+    private String title;
+    private LocalDateTime createdAt;
+
+    public static HotArticleResponse from(ArticleClient.ArticleResponse articleResponse) {
+        HotArticleResponse response = new HotArticleResponse();
+        response.articleId = articleResponse.getArticleId();
+        response.title = articleResponse.getTitle();
+        response.createdAt = articleResponse.getCreatedAt();
+        return response;
+    }
+}

--- a/backend/hot-article/src/main/java/com/example/hotarticle/utils/TimeCalculator.java
+++ b/backend/hot-article/src/main/java/com/example/hotarticle/utils/TimeCalculator.java
@@ -1,0 +1,16 @@
+package com.example.hotarticle.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeCalculator {
+    public static Duration calculateDurationToMidnight(LocalDateTime now) {
+        LocalDateTime midnight = now.plusDays(1).with(LocalTime.MIDNIGHT);
+        return Duration.between(now, midnight);
+    }
+}

--- a/backend/hot-article/src/main/resources/application.yml
+++ b/backend/hot-article/src/main/resources/application.yml
@@ -3,3 +3,17 @@ server:
 spring:
   application:
     name: article-hot-service
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: board-hot-article-service
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+endpoints:
+  board-article-service:
+    url: http://127.0.0.1:9000

--- a/backend/hot-article/src/main/resources/application.yml
+++ b/backend/hot-article/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       enable-auto-commit: false
+      auto-offset-reset: earliest
+    properties:
+      spring.json.trusted.packages: '*'
 endpoints:
   board-article-service:
     url: http://127.0.0.1:9000

--- a/backend/hot-article/src/test/java/com/example/hotarticle/EmbeddedRedis.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/EmbeddedRedis.java
@@ -1,0 +1,77 @@
+package com.example.hotarticle;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import redis.embedded.RedisServer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@TestConfiguration
+public class EmbeddedRedis {
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void start() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : redisPort;
+        this.redisServer = new RedisServer(port);
+        this.redisServer.start();
+    }
+
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(redisPort));
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null) {
+            this.redisServer.stop();
+        }
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+        for(int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if(!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN | grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try(BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+        } catch (Exception e) {}
+
+        String result = pidInfo.toString();
+        return !result.isEmpty();
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/api/DataInitializer.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/api/DataInitializer.java
@@ -1,0 +1,110 @@
+package com.example.hotarticle.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.random.RandomGenerator;
+
+@Disabled
+public class DataInitializer {
+    RestClient articleServiceClient = RestClient.create("http://localhost:9000");
+    RestClient commentServiceClient = RestClient.create("http://localhost:9001");
+    RestClient likeServiceClient = RestClient.create("http://localhost:9002");
+    RestClient viewServiceClient = RestClient.create("http://localhost:9003");
+
+    @Test
+    void initialize() {
+        for(int i=0; i< 30; i++) {
+            Long articleId = createArticle(i);
+            long commentCount = 1 + RandomGenerator.getDefault().nextLong(10);
+            long likeCount = 1 + RandomGenerator.getDefault().nextLong(10);
+            long viewCount = 1 + RandomGenerator.getDefault().nextLong(200);
+
+            System.out.printf("articleId = %d, comment=%d, like=%d, view=%d%n", articleId, commentCount, likeCount, viewCount);
+
+            createComment(articleId, commentCount);
+            like(articleId, likeCount);
+            view(articleId, viewCount);
+        }
+    }
+
+    Long createArticle(int no) {
+        return articleServiceClient.post()
+                .uri("/v1/article")
+                .body(new ArticleCreateRequest("title" + no, "content" + no, 1L, 1L))
+                .retrieve()
+                .body(ArticleResponse.class)
+                .getArticleId();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class ArticleCreateRequest {
+        private String title;
+        private String content;
+        private Long writerId;
+        private Long boardId;
+    }
+
+    @Getter
+    static class ArticleResponse {
+        private Long articleId;
+    }
+
+    void createComment(Long articleId, long commentCount) {
+        for(int i = 1; i <= commentCount; i++) {
+            commentServiceClient.post()
+                    .uri("/v2/comment")
+                    .body(new CommentCreateRequest(articleId, "content", (long) i))
+                    .retrieve()
+                    .body(CommentCreateResponse.class);
+
+            commentCount -= 1;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class CommentCreateRequest {
+        private Long articleId;
+        private String content;
+        private Long writerId;
+    }
+
+    @Getter
+    @ToString
+    @AllArgsConstructor
+    static class CommentCreateResponse {
+        private Long commentId;
+        private String content;
+        private Long articleId;
+        private Long writerId;
+        private Boolean deleted;
+        private String path;
+        private LocalDateTime createdAt;
+    }
+
+    void like(Long articleId, long likeCount) {
+        for(int i = 1; i <= likeCount; i++) {
+            ResponseEntity<Void> response = likeServiceClient.post()
+                    .uri("/v1/article-like/article/{articleId}/user/{userId}", articleId, i)
+                    .retrieve()
+                    .toBodilessEntity();
+        }
+    }
+
+    void view(Long articleId, long viewCount) {
+        for(int i = 1; i <= viewCount; i++) {
+            viewServiceClient.post()
+                    .uri("/v1/article-view/article/{articleId}/user/{userId}", articleId, i)
+                    .retrieve()
+                    .toBodilessEntity();
+        }
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/api/HotArticleApiTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/api/HotArticleApiTest.java
@@ -1,0 +1,31 @@
+package com.example.hotarticle.api;
+
+import com.example.hotarticle.service.response.HotArticleResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Disabled
+public class HotArticleApiTest {
+    RestClient restClient = RestClient.create("http://localhost:9004");
+
+    @Test
+    void readAllTest() {
+        LocalDate today = LocalDate.now();
+        String yyyyMMdd = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        List<HotArticleResponse> responses = restClient.get()
+                .uri("/v1/hot-articles/articles/date/{dateStr}", yyyyMMdd)
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+
+        for (HotArticleResponse response : responses) {
+            System.out.println("response = " + response);
+        }
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/client/ArticleClientTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/client/ArticleClientTest.java
@@ -1,0 +1,64 @@
+package com.example.hotarticle.client;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/*
+reference
+- https://www.youtube.com/watch?v=-ChpDCIjyh0
+- https://jojoldu.tistory.com/341
+ */
+@ActiveProfiles("test")
+@RestClientTest(ArticleClient.class)
+class ArticleClientTest {
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @Autowired
+    private ArticleClient articleClient;
+
+    @Value("${endpoints.board-article-service.url}")
+    private String articleServiceUrl;
+
+    @Test
+    void read() {
+        Long articleId = 1L;
+        String expectedJson = """
+            {
+                "articleId": 1,
+                "title": "Test Article",
+                "createdAt": "2025-07-01T12:00:00"
+            }
+            """;
+
+        // 응답 설정
+        mockServer.expect(requestTo(articleServiceUrl + "/v1/article/1"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(expectedJson, MediaType.APPLICATION_JSON));
+
+        // 호출
+        ArticleClient.ArticleResponse response = articleClient.read(articleId);
+
+        // 검증
+        assertThat(response).isNotNull();
+        assertThat(response.getArticleId()).isEqualTo(1L);
+        assertThat(response.getTitle()).isEqualTo("Test Article");
+        assertThat(response.getCreatedAt()).isEqualTo(LocalDateTime.of(2025, 7, 1, 12, 0));
+
+        mockServer.verify();
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/consumer/EmbeddedKafkaEventConsumerTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/consumer/EmbeddedKafkaEventConsumerTest.java
@@ -1,0 +1,58 @@
+package com.example.hotarticle.consumer;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleCreatedEventPayload;
+import com.example.hotarticle.service.HotArticleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConfiguration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@EnableKafka
+@ActiveProfiles("test")
+@SpringBootTest
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {"listener=PLAINTEXT://localhost:9092"},
+        topics = {EventType.Topic.BOARD_ARTICLE, EventType.Topic.BOARD_COMMENT, EventType.Topic.BOARD_LIKE, EventType.Topic.BOARD_VIEW})
+class EmbeddedKafkaEventConsumerTest {
+
+    @MockitoBean
+    private RedisConfiguration redisConfiguration;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @MockitoBean
+    private HotArticleService hotArticleService;
+
+    @Test
+    void listener() throws InterruptedException {
+        Long articleId = 10L;
+        LocalDateTime now = LocalDateTime.now();
+        ArticleCreatedEventPayload payload
+                = new ArticleCreatedEventPayload(articleId, "title", "content", 1L, 1L, now, now, 0L);
+
+        Event<EventPayload> event = Event.of(articleId, EventType.ARTICLE_CREATED, payload);
+        kafkaTemplate.send(EventType.Topic.BOARD_ARTICLE, event.toJson());
+        kafkaTemplate.flush();
+
+        Thread.sleep(1000);
+
+        verify(hotArticleService, atLeastOnce()).handleEvent(any());
+    }
+
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/consumer/HotArticleEventConsumerTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/consumer/HotArticleEventConsumerTest.java
@@ -1,0 +1,55 @@
+package com.example.hotarticle.consumer;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleCreatedEventPayload;
+import com.example.hotarticle.service.HotArticleService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HotArticleEventConsumerTest {
+
+    @InjectMocks
+    private HotArticleEventConsumer consumer;
+
+    @Mock
+    private HotArticleService hotArticleService;
+
+    @Captor
+    ArgumentCaptor<Event<EventPayload>> eventCaptor;
+
+    @Test
+    void listener() throws JsonProcessingException {
+        Long articleId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        ArticleCreatedEventPayload payload
+                = new ArticleCreatedEventPayload(articleId, "title", "content", 1L, 1L, now, now, 0L);
+
+        Event<EventPayload> event = Event.of(articleId, EventType.ARTICLE_CREATED, payload);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        consumer.listener(event.toJson(), acknowledgment);
+
+        verify(acknowledgment).acknowledge();
+        verify(hotArticleService).handleEvent(eventCaptor.capture());
+        Event<EventPayload> captured = eventCaptor.getValue();
+        assertThat(captured.getEventId()).isEqualTo(articleId);
+        assertThat(captured.getType()).isEqualTo(EventType.ARTICLE_CREATED);
+        assertThat(captured.getPayload()).isInstanceOf(ArticleCreatedEventPayload.class);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/consumer/HotArticleEventConsumerTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/consumer/HotArticleEventConsumerTest.java
@@ -5,7 +5,6 @@ import com.example.event.EventPayload;
 import com.example.event.EventType;
 import com.example.event.paylod.ArticleCreatedEventPayload;
 import com.example.hotarticle.service.HotArticleService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -34,7 +33,7 @@ class HotArticleEventConsumerTest {
     ArgumentCaptor<Event<EventPayload>> eventCaptor;
 
     @Test
-    void listener() throws JsonProcessingException {
+    void listener() {
         Long articleId = 1L;
         LocalDateTime now = LocalDateTime.now();
         ArticleCreatedEventPayload payload

--- a/backend/hot-article/src/test/java/com/example/hotarticle/controller/HotArticleControllerTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/controller/HotArticleControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.hotarticle.controller;
+
+import com.example.hotarticle.service.HotArticleService;
+import com.example.hotarticle.service.response.HotArticleResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(HotArticleController.class)
+class HotArticleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HotArticleService hotArticleService;
+
+    @Test
+    void readAll() throws Exception {
+        String dateStr = "20250701";
+        long articleId = 1L;
+        String title = "title";
+        LocalDateTime createdAt = LocalDateTime.of(2025, 7, 1, 1, 0, 0);
+        HotArticleResponse response = new HotArticleResponse(articleId, title, createdAt);
+
+        Mockito.when(hotArticleService.readAll(dateStr))
+                        .thenReturn(List.of(response));
+
+        mockMvc.perform(get("/v1/hot-articles/articles/date/{dateStr}", dateStr))
+                .andExpectAll(status().isOk(),
+                        jsonPath("$[0].articleId").value(articleId),
+                        jsonPath("$[0].title").value(title),
+                        jsonPath("$[0].createdAt").value("2025-07-01T01:00:00"));
+
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleCommentCountRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleCommentCountRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.example.hotarticle.repository;
+
+import com.example.hotarticle.EmbeddedRedis;
+import com.example.hotarticle.config.KafkaConfig;
+import com.example.hotarticle.consumer.HotArticleEventConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(EmbeddedRedis.class)
+@SpringBootTest
+class ArticleCommentCountRepositoryTest {
+
+    @Autowired
+    private ArticleCommentCountRepository articleCommentCountRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    // kafka 로그 제거
+    @MockitoBean
+    private KafkaConfig kafkaConfig;
+
+    @MockitoBean
+    private HotArticleEventConsumer hotArticleEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        RedisConnectionFactory connectionFactory = redisTemplate.getConnectionFactory();
+        RedisConnection connection = connectionFactory.getConnection();
+        connection.serverCommands().flushAll();
+
+        articleCommentCountRepository.createOrUpdate(1L, 100L, Duration.ofSeconds(30));
+    }
+
+    @Test
+    void read() {
+        Long articleId = 1L;
+
+        Long actual = articleCommentCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void create() {
+        Long articleId = 2L;
+        Long commentCount = 100L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleCommentCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleCommentCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void update() {
+        Long articleId = 1L;
+        Long commentCount = 200L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleCommentCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleCommentCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(200L);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleCreatedTimeRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleCreatedTimeRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.example.hotarticle.repository;
+
+import com.example.hotarticle.EmbeddedRedis;
+import com.example.hotarticle.config.KafkaConfig;
+import com.example.hotarticle.consumer.HotArticleEventConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(EmbeddedRedis.class)
+@ActiveProfiles("test")
+@SpringBootTest
+class ArticleCreatedTimeRepositoryTest {
+
+    @Autowired
+    private ArticleCreatedTimeRepository articleCreatedTimeRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    // kafka 로그 제거
+    @MockitoBean
+    private KafkaConfig kafkaConfig;
+
+    @MockitoBean
+    private HotArticleEventConsumer hotArticleEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        RedisConnectionFactory connectionFactory = redisTemplate.getConnectionFactory();
+        RedisConnection connection = connectionFactory.getConnection();
+        connection.serverCommands().flushAll();
+
+        articleCreatedTimeRepository.createOrUpdate(1L, LocalDateTime.of(2025, 7, 1, 12, 0, 0), Duration.ofSeconds(30));
+    }
+
+    @Test
+    void read() {
+        Long articleId = 1L;
+
+        LocalDateTime actual = articleCreatedTimeRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(LocalDateTime.of(2025, 7, 1, 12, 0, 0));
+    }
+
+    @Test
+    void create() {
+        Long articleId = 2L;
+        LocalDateTime createdAt = LocalDateTime.of(2025, 7, 2, 0, 0, 0);
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleCreatedTimeRepository.createOrUpdate(articleId, createdAt, ttl);
+
+        LocalDateTime actual = articleCreatedTimeRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(createdAt);
+    }
+
+    @Test
+    void update() {
+        Long articleId = 1L;
+        LocalDateTime createdAt = LocalDateTime.of(2025, 7, 1, 12, 1, 0);
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleCreatedTimeRepository.createOrUpdate(articleId, createdAt, ttl);
+
+        LocalDateTime actual = articleCreatedTimeRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(createdAt);
+    }
+
+    @Test
+    void delete() {
+        Long articleId = 1L;
+
+        articleCreatedTimeRepository.delete(articleId);
+
+        LocalDateTime actual = articleCreatedTimeRepository.read(articleId);
+
+        assertThat(actual).isNull();
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleLikeCountRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleLikeCountRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.example.hotarticle.repository;
+
+import com.example.hotarticle.EmbeddedRedis;
+import com.example.hotarticle.config.KafkaConfig;
+import com.example.hotarticle.consumer.HotArticleEventConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(EmbeddedRedis.class)
+@SpringBootTest
+class ArticleLikeCountRepositoryTest {
+
+    @Autowired
+    private ArticleLikeCountRepository articleLikeCountRepository;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    // kafka 로그 제거
+    @MockitoBean
+    private KafkaConfig kafkaConfig;
+
+    @MockitoBean
+    private HotArticleEventConsumer hotArticleEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        RedisConnectionFactory connectionFactory = stringRedisTemplate.getConnectionFactory();
+        RedisConnection connection = connectionFactory.getConnection();
+        connection.serverCommands().flushAll();
+
+        articleLikeCountRepository.createOrUpdate(1L, 100L, Duration.ofSeconds(30));
+    }
+
+    @Test
+    void read() {
+        Long articleId = 1L;
+
+        Long actual = articleLikeCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void create() {
+        Long articleId = 2L;
+        Long commentCount = 100L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleLikeCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleLikeCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void update() {
+        Long articleId = 1L;
+        Long commentCount = 200L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleLikeCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleLikeCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(200L);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleViewCountRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/ArticleViewCountRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.example.hotarticle.repository;
+
+import com.example.hotarticle.EmbeddedRedis;
+import com.example.hotarticle.config.KafkaConfig;
+import com.example.hotarticle.consumer.HotArticleEventConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(EmbeddedRedis.class)
+@SpringBootTest
+class ArticleViewCountRepositoryTest {
+
+    @Autowired
+    private ArticleViewCountRepository articleViewCountRepository;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    // kafka 로그 제거
+    @MockitoBean
+    private KafkaConfig kafkaConfig;
+
+    @MockitoBean
+    private HotArticleEventConsumer hotArticleEventConsumer;
+
+    @BeforeEach
+    void setUp() {
+        RedisConnectionFactory connectionFactory = stringRedisTemplate.getConnectionFactory();
+        RedisConnection connection = connectionFactory.getConnection();
+        connection.serverCommands().flushAll();
+
+        articleViewCountRepository.createOrUpdate(1L, 100L, Duration.ofSeconds(30));
+    }
+
+    @Test
+    void read() {
+        Long articleId = 1L;
+
+        Long actual = articleViewCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void create() {
+        Long articleId = 2L;
+        Long commentCount = 100L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleViewCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleViewCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(100L);
+    }
+
+    @Test
+    void update() {
+        Long articleId = 1L;
+        Long commentCount = 200L;
+        Duration ttl = Duration.ofSeconds(30);
+
+        articleViewCountRepository.createOrUpdate(articleId, commentCount, ttl);
+
+        Long actual = articleViewCountRepository.read(articleId);
+
+        assertThat(actual).isEqualTo(200L);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
@@ -1,15 +1,19 @@
 package com.example.hotarticle.repository;
 
 import com.example.hotarticle.EmbeddedRedis;
+import com.example.hotarticle.config.KafkaConfig;
+import com.example.hotarticle.consumer.HotArticleEventConsumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,8 +23,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class HotArticleListRepositoryTest {
 
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
     @Autowired
     private HotArticleListRepository hotArticleListRepository;
+
+    // kafka 로그 제거
+    @MockitoBean
+    private KafkaConfig kafkaConfig;
+
+    @MockitoBean
+    private HotArticleEventConsumer hotArticleEventConsumer;
 
     @Test
     void add() {
@@ -33,7 +46,7 @@ class HotArticleListRepositoryTest {
             hotArticleListRepository.add(articleId, now, (long) i, limit, ttl);
         }
 
-        List<Long> result = hotArticleListRepository.readAll(now);
+        List<Long> result = hotArticleListRepository.readAll(FORMATTER.format(now));
 
         assertThat(result).hasSize(5)
                 .containsExactly(10L, 9L, 8L, 7L, 6L);
@@ -53,7 +66,7 @@ class HotArticleListRepositoryTest {
 
         hotArticleListRepository.remove(1L, now);
 
-        List<Long> result = hotArticleListRepository.readAll(now);
+        List<Long> result = hotArticleListRepository.readAll(FORMATTER.format(now));
 
         assertThat(result).hasSize(4)
                 .containsExactly(5L, 4L, 3L, 2L);

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.hotarticle.repository;
 
 import com.example.hotarticle.EmbeddedRedis;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,5 +37,25 @@ class HotArticleListRepositoryTest {
 
         assertThat(result).hasSize(5)
                 .containsExactly(10L, 9L, 8L, 7L, 6L);
+    }
+
+    @DisplayName("(article 삭제 이벤트 발생시) hot-article을 삭제한다")
+    @Test
+    void remove() {
+        Long limit = 5L;
+        Duration ttl = Duration.ofMinutes(1);
+        LocalDateTime now = LocalDateTime.now();
+
+        for(int i = 1; i <= 5; i++) {
+            Long articleId = (long) i;
+            hotArticleListRepository.add(articleId, now, (long) i, limit, ttl);
+        }
+
+        hotArticleListRepository.remove(1L, now);
+
+        List<Long> result = hotArticleListRepository.readAll(now);
+
+        assertThat(result).hasSize(4)
+                .containsExactly(5L, 4L, 3L, 2L);
     }
 }

--- a/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/repository/HotArticleListRepositoryTest.java
@@ -1,0 +1,40 @@
+package com.example.hotarticle.repository;
+
+import com.example.hotarticle.EmbeddedRedis;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(EmbeddedRedis.class)
+@SpringBootTest
+class HotArticleListRepositoryTest {
+
+    @Autowired
+    private HotArticleListRepository hotArticleListRepository;
+
+    @Test
+    void add() {
+        Long limit = 5L;
+        Duration ttl = Duration.ofMinutes(1);
+        LocalDateTime now = LocalDateTime.now();
+
+        for(int i = 1; i <= 10; i++) {
+            Long articleId = (long) i;
+            hotArticleListRepository.add(articleId, now, (long) i, limit, ttl);
+        }
+
+        List<Long> result = hotArticleListRepository.readAll(now);
+
+        assertThat(result).hasSize(5)
+                .containsExactly(10L, 9L, 8L, 7L, 6L);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleScoreCalculatorTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleScoreCalculatorTest.java
@@ -1,0 +1,54 @@
+package com.example.hotarticle.service;
+
+import com.example.hotarticle.repository.ArticleCommentCountRepository;
+import com.example.hotarticle.repository.ArticleLikeCountRepository;
+import com.example.hotarticle.repository.ArticleViewCountRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.random.RandomGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HotArticleScoreCalculatorTest {
+
+    @InjectMocks
+    private HotArticleScoreCalculator hotArticleScoreCalculator;
+
+    @Mock
+    private ArticleLikeCountRepository articleLikeCountRepository;
+
+    @Mock
+    private ArticleViewCountRepository articleViewCountRepository;
+
+    @Mock
+    private ArticleCommentCountRepository articleCommentCountRepository;
+
+    @Test
+    void calculate() {
+        Long articleId = 1L;
+        Long likeCount = getRandomCount();
+        Long viewCount = getRandomCount();
+        Long commentCount = getRandomCount();
+
+        when(articleLikeCountRepository.read(articleId))
+                .thenReturn(likeCount);
+        when(articleViewCountRepository.read(articleId))
+                .thenReturn(viewCount);
+        when(articleCommentCountRepository.read(articleId))
+                .thenReturn(commentCount);
+
+        long score = hotArticleScoreCalculator.calculate(articleId);
+
+        assertThat(score).isEqualTo(3 * likeCount + 2 * commentCount + 1 * viewCount);
+    }
+
+    private static long getRandomCount() {
+        return RandomGenerator.getDefault().nextLong(100L);
+    }
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleScoreUpdaterTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleScoreUpdaterTest.java
@@ -1,0 +1,79 @@
+package com.example.hotarticle.service;
+
+import com.example.event.Event;
+import com.example.hotarticle.repository.ArticleCreatedTimeRepository;
+import com.example.hotarticle.repository.HotArticleListRepository;
+import com.example.hotarticle.service.eventhandler.EventHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HotArticleScoreUpdaterTest {
+
+    @InjectMocks
+    private HotArticleScoreUpdater hotArticleScoreUpdater;
+
+    @Mock
+    private ArticleCreatedTimeRepository articleCreatedTimeRepository;
+
+    @Mock
+    private HotArticleScoreCalculator hotArticleScoreCalculator;
+
+    @Mock
+    private HotArticleListRepository hotArticleListRepository;
+
+    @Test
+    void updateIfArticleNotCreatedToday() {
+        Long articleId = 1L;
+        Event event = mock(Event.class);
+        EventHandler eventHandler = mock(EventHandler.class);
+
+        when(eventHandler.findArticleId(event))
+                .thenReturn(articleId);
+
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        when(articleCreatedTimeRepository.read(articleId))
+                .thenReturn(yesterday);
+
+        hotArticleScoreUpdater.update(event, eventHandler);
+
+        verify(eventHandler, never()).handle(event);
+        verify(hotArticleListRepository, never())
+                .add(anyLong(), any(LocalDateTime.class), anyLong(), anyLong(), any(Duration.class));
+    }
+
+    @Test
+    void update() {
+        Long articleId = 1L;
+        Event event = mock(Event.class);
+        EventHandler eventHandler = mock(EventHandler.class);
+
+        when(eventHandler.findArticleId(event))
+                .thenReturn(articleId);
+
+        LocalDateTime today = LocalDateTime.now();
+        when(articleCreatedTimeRepository.read(articleId))
+                .thenReturn(today);
+
+        hotArticleScoreUpdater.update(event, eventHandler);
+
+        verify(eventHandler).handle(event);
+        verify(hotArticleListRepository, times(1))
+                .add(anyLong(), any(LocalDateTime.class), anyLong(), anyLong(), any(Duration.class));
+    }
+
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleServiceTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/service/HotArticleServiceTest.java
@@ -1,0 +1,111 @@
+package com.example.hotarticle.service;
+
+import com.example.event.Event;
+import com.example.event.EventPayload;
+import com.example.event.EventType;
+import com.example.event.paylod.ArticleCreatedEventPayload;
+import com.example.event.paylod.ArticleLikedEventPayload;
+import com.example.hotarticle.client.ArticleClient;
+import com.example.hotarticle.repository.HotArticleListRepository;
+import com.example.hotarticle.service.eventhandler.EventHandler;
+import com.example.hotarticle.service.response.HotArticleResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HotArticleServiceTest {
+
+    private HotArticleService hotArticleService;
+
+    @Mock
+    private ArticleClient articleClient;
+
+    @Mock
+    private EventHandler<EventPayload> eventHandler;
+
+    @Mock
+    private HotArticleScoreUpdater hotArticleScoreUpdater;
+
+    @Mock
+    private HotArticleListRepository hotArticleListRepository;
+
+    @BeforeEach
+    void setUp() {
+        this.hotArticleService = new HotArticleService(articleClient,
+                List.of(eventHandler),
+                hotArticleScoreUpdater,
+                hotArticleListRepository);
+    }
+
+    @Test
+    void handleEventWhenUnknownEvent() {
+        hotArticleService.handleEvent(null);
+
+        verify(eventHandler, never()).handle(any());
+        verify(hotArticleScoreUpdater, never()).update(any(), any());
+    }
+
+    @Test
+    void handleEventWhenArticleCreatedEvent() {
+        // given
+        Event<EventPayload> event = Event.of(1L, EventType.ARTICLE_CREATED, new ArticleCreatedEventPayload());
+
+        when(eventHandler.support(event)).thenReturn(true);
+
+        // when
+        hotArticleService.handleEvent(event);
+
+        // then
+        verify(eventHandler).handle(event);
+        verifyNoInteractions(hotArticleScoreUpdater);
+    }
+
+    @Test
+    void handleEventWhenArticleLikedEvent() {
+        Event<EventPayload> event = Event.of(1L, EventType.ARTICLE_LIKED, new ArticleLikedEventPayload());
+
+        when(eventHandler.support(event)).thenReturn(true);
+
+        // when
+        hotArticleService.handleEvent(event);
+
+        // then
+        verify(eventHandler, never()).handle(event);
+        verify(hotArticleScoreUpdater, times(1)).update(any(), any());
+    }
+
+    @Test
+    void readAll() {
+        String dateStr = "20250701";
+        List<Long> articleId = List.of(1L, 2L);
+
+        ArticleClient.ArticleResponse articleResponse1 = new ArticleClient.ArticleResponse(1L, "제목1", LocalDateTime.of(2025, 6, 30, 1, 0, 0));
+        ArticleClient.ArticleResponse articleResponse2 = new ArticleClient.ArticleResponse(2L, "제목2", LocalDateTime.of(2025, 6, 30, 2, 0, 0));
+
+        when(hotArticleListRepository.readAll(dateStr)).thenReturn(articleId);
+        when(articleClient.read(1L)).thenReturn(articleResponse1);
+        when(articleClient.read(2L)).thenReturn(articleResponse2);
+
+        List<HotArticleResponse> result = hotArticleService.readAll(dateStr);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(HotArticleResponse::getArticleId)
+                .containsExactly(1L, 2L);
+
+    }
+
+}

--- a/backend/hot-article/src/test/java/com/example/hotarticle/utils/TimeCalculatorTest.java
+++ b/backend/hot-article/src/test/java/com/example/hotarticle/utils/TimeCalculatorTest.java
@@ -1,0 +1,25 @@
+package com.example.hotarticle.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class TimeCalculatorTest {
+
+    @DisplayName("현재 시간에서 자정까지 남은 시간을 계산한다")
+    @Test
+    void calculateDurationToMidnight() {
+        LocalDateTime now = LocalDateTime.of(2025, 7, 11, 12, 0, 0);
+        Duration duration = TimeCalculator.calculateDurationToMidnight(now);
+
+        assertThat(duration).isEqualTo(Duration.ofHours(12));
+
+        log.info("duration.getSeconds() / 60 = {}", duration.getSeconds() / 60);
+    }
+}

--- a/backend/hot-article/src/test/resources/application-test.yml
+++ b/backend/hot-article/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/backend/hot-article/src/test/resources/application-test.yml
+++ b/backend/hot-article/src/test/resources/application-test.yml
@@ -3,3 +3,6 @@ spring:
     redis:
       host: localhost
       port: 6379
+endpoints:
+  board-article-service:
+    url: http://127.0.0.1:9000

--- a/backend/like/build.gradle
+++ b/backend/like/build.gradle
@@ -4,4 +4,6 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
     implementation project(':backend:common:snowflake')
+    implementation project(':backend:common:event')
+    implementation project(':backend:common:outbox-message-relay')
 }

--- a/backend/like/src/main/java/com/example/like/LikeApplication.java
+++ b/backend/like/src/main/java/com/example/like/LikeApplication.java
@@ -2,7 +2,11 @@ package com.example.like;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example")
 @SpringBootApplication
 public class LikeApplication {
     public static void main(String[] args) {

--- a/backend/like/src/main/java/com/example/like/controller/ArticleLikeController.java
+++ b/backend/like/src/main/java/com/example/like/controller/ArticleLikeController.java
@@ -3,6 +3,7 @@ package com.example.like.controller;
 import com.example.like.service.ArticleLikeService;
 import com.example.like.service.response.ArticleLikeResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ArticleLikeController {
@@ -29,6 +31,7 @@ public class ArticleLikeController {
             @PathVariable("articleId") Long articleId,
             @PathVariable("userId") Long userId
     ) {
+        log.info("ArticleLikeController like articleId = {}, userId = {}", articleId, userId);
         articleLikeService.like(articleId, userId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(null);

--- a/backend/like/src/main/resources/application.yml
+++ b/backend/like/src/main/resources/application.yml
@@ -3,3 +3,20 @@ server:
 spring:
   application:
     name: article-like-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/article_like
+    username: tester
+    password: 1234
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+  kafka:
+    bootstrap-servers: 127.0.0.1:9092

--- a/backend/like/src/test/java/com/example/like/controller/ArticleLikeControllerTest.java
+++ b/backend/like/src/test/java/com/example/like/controller/ArticleLikeControllerTest.java
@@ -4,6 +4,7 @@ import com.example.like.entity.ArticleLike;
 import com.example.like.entity.ArticleLikeCount;
 import com.example.like.repository.ArticleLikeCountRepository;
 import com.example.like.repository.ArticleLikeRepository;
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -42,6 +44,9 @@ class ArticleLikeControllerTest {
 
     @Autowired
     private ArticleLikeCountRepository articleLikeCountRepository;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     @BeforeEach
     void setUp() {

--- a/backend/like/src/test/java/com/example/like/service/ArticleLikeServiceTest.java
+++ b/backend/like/src/test/java/com/example/like/service/ArticleLikeServiceTest.java
@@ -2,11 +2,13 @@ package com.example.like.service;
 
 import com.example.like.entity.ArticleLikeCount;
 import com.example.like.repository.ArticleLikeCountRepository;
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -28,6 +30,9 @@ class ArticleLikeServiceTest {
 
     @Autowired
     private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     @BeforeEach
     void setUp() {

--- a/backend/like/src/test/resources/application-test.yml
+++ b/backend/like/src/test/resources/application-test.yml
@@ -3,6 +3,7 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -12,3 +13,5 @@ spring:
       hibernate:
         format_sql: false
     defer-datasource-initialization: true
+  autoconfigure:
+    exclude: com.example.outboxmessagerelay.MessageRelayConfig

--- a/backend/view/build.gradle
+++ b/backend/view/build.gradle
@@ -8,4 +8,6 @@ dependencies {
     testImplementation 'com.github.codemonstur:embedded-redis:1.0.0'
 
     implementation project(':backend:common:snowflake')
+    implementation project(':backend:common:event')
+    implementation project(':backend:common:outbox-message-relay')
 }

--- a/backend/view/src/main/java/com/example/view/ViewApplication.java
+++ b/backend/view/src/main/java/com/example/view/ViewApplication.java
@@ -2,7 +2,11 @@ package com.example.view;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EntityScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example")
 @SpringBootApplication
 public class ViewApplication {
 

--- a/backend/view/src/main/java/com/example/view/controller/ArticleViewController.java
+++ b/backend/view/src/main/java/com/example/view/controller/ArticleViewController.java
@@ -2,12 +2,14 @@ package com.example.view.controller;
 
 import com.example.view.service.ArticleViewService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ArticleViewController {
@@ -15,6 +17,7 @@ public class ArticleViewController {
 
     @PostMapping("/v1/article-view/article/{articleId}/user/{userId}")
     public ResponseEntity<Long> increase(@PathVariable("articleId") Long articleId, @PathVariable("userId") Long userId) {
+        log.info("ArticleViewController articleId  = {}, userId = {}", articleId, userId);
         return ResponseEntity.ok(articleViewService.increase(articleId, userId));
     }
 

--- a/backend/view/src/main/resources/application.yml
+++ b/backend/view/src/main/resources/application.yml
@@ -3,8 +3,20 @@ server:
 spring:
   application:
     name: article-view-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/article_view
+    username: tester
+    password: 1234
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: none
   data:
     redis:
-      host: localhost
+      host: 127.0.0.1
       port: 6379
-
+  kafka:
+    bootstrap-servers: 127.0.0.1:9092

--- a/backend/view/src/test/java/com/example/view/service/ArticleViewServiceTest.java
+++ b/backend/view/src/test/java/com/example/view/service/ArticleViewServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.view.service;
 
+import com.example.outboxmessagerelay.OutboxEventPublisher;
 import com.example.view.EmbeddedRedis;
 import com.example.view.entity.ArticleViewCount;
 import com.example.view.repository.ArticleViewCountBackUpRepository;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +29,9 @@ class ArticleViewServiceTest {
 
     @Autowired
     private ArticleViewCountBackUpRepository articleViewCountBackUpRepository;
+
+    @MockitoBean
+    private OutboxEventPublisher outboxEventPublisher;
 
     @BeforeEach
     void setUp() {

--- a/backend/view/src/test/resources/application-test.yml
+++ b/backend/view/src/test/resources/application-test.yml
@@ -1,4 +1,18 @@
 spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+    defer-datasource-initialization: true
   data:
     redis:
       host: localhost

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ allprojects {
     }
 
     dependencies {
+        implementation 'ch.qos.logback:logback-classic'
+
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 

--- a/docker/schema.sql
+++ b/docker/schema.sql
@@ -83,3 +83,16 @@ create table article_view_count (
     article_id bigint not null primary key,
     view_count bigint not null
 );
+
+-- 인기글
+-- article, article_view, article_like, comment DB에 각각 테이블과 인덱스 생성해준다
+create table outbox (
+    outbox_id bigint not null primary key,
+    shard_key bigint not null,
+    event_type varchar(100) not null,
+    payload varchar(5000) not null,
+    created_at datetime not null
+);
+
+-- 생성 10초 이후 조건 조회를 위한 인덱스
+create index idx_shard_key_created_at on outbox(shard_key asc, created_at asc);

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,4 @@ rootProject.name = 'boardx'
 
 include('backend')
 include('backend:article', 'backend:article-read', 'backend:comment', 'backend:hot-article', 'backend:like', 'backend:view')
-include('backend:common', 'backend:common:snowflake', 'backend:common:support')
+include('backend:common', 'backend:common:snowflake', 'backend:common:support', 'backend:common:data-serializer', 'backend:common:event')

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,4 @@ rootProject.name = 'boardx'
 
 include('backend')
 include('backend:article', 'backend:article-read', 'backend:comment', 'backend:hot-article', 'backend:like', 'backend:view')
-include('backend:common', 'backend:common:snowflake', 'backend:common:support', 'backend:common:data-serializer', 'backend:common:event')
+include('backend:common', 'backend:common:snowflake', 'backend:common:support', 'backend:common:data-serializer', 'backend:common:event', 'backend:common:outbox-message-relay')


### PR DESCRIPTION
## Flow
<img width="1120" height="669" alt="hot-article-flow" src="https://github.com/user-attachments/assets/495617df-1288-4b85-a87b-ec30b3087d77" />

**Consumer(hot-article)**
- `common:event` 모듈 의존
- `hot-article` 모듈은 인기글에 필요한 정보를 kafka 통해 메시지 전달 받음 
  - 게시글 생성/삭제
  - 좋아요수, 댓글수, 조회수 (가중치 부여하여 점수 계산)
-  금일 기준 신규 생성된 게시글에 한하여 score를 계산하고 redis에 인기글 및 부가 정보 저장
   - 사용자는 이전 날짜 기준으로 인기글을 조회하게 됨
- 이때 hot-article 모듈은 article / comment / view / like 모듈을 알 필요가 없다 (의존 x). 단지 메시지를 전달받아 처리할 뿐이다

**Producer(article / comment / view / like)**
- `common:outbox-message-relay`, `common:event`  모듈 의존
  - 역할1. OutboxPublisher를 통해 전달받은 이벤트를 kafka에 send 
  - 역할2. 스케쥴러 통해 각 프로세스 정보를 Redis 저장/관리
  - 역할3. 미처리된 outbox 메시지가 있는 경우, 프로세스별 샤드 동적 할당하여 메시지 재발송 처리 (이미지 참고)
- 인기글 관련 이벤트 발생시 OutboxPublisher를 통해 메시지 발행 


## TroubleShooting
<img width="955" height="808" alt="hot-article-event" src="https://github.com/user-attachments/assets/337f4eb1-30f4-45f8-8cd1-336bf6f5e974" />

- HotArticleService에서 EventHandler 빈 초기화 이슈
  - 제네릭 타입이 맞지 않아 컨테이너 초기화시 빈 주입이 되지 않은 것으로 확인 
  - before : `private final List<EventHandler<EventPayload>> eventHandlers;` 
  - after : `private final List<EventHandler> eventHandlers`
- `ARTICLE_UPDATED` 미사용 => `article-read` 모듈에서 사용
  - `hot-article` 모듈에 ArticleUpdatedEventHandler가 없는데, `article` 모듈에서 update시 이벤트 발행 
  - EventHandler 컬렉션에 없는 경우 안전하게 return 처리 해두어 이상 없는 것으로 확인 
  - 비즈니스 로직 필요시 EventHandler 구현만 하면 됨 
-  `common:outbox-message-relay` 모듈 추가로 인한 테스트 실패 ( 대상: article / comment / view / like 모듈)
   -  `common:outbox-message-relay` 모듈을 추가하면서 redis, kafka 설정이 필요하여 테스트 실패 확인 
   - @MockitoBean과  `spring:autoconfigure:exclude: com.example.outboxmessagerelay.MessageRelayConfig` 설정 추가하여 해결

